### PR TITLE
+ Fixed warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 
 [[package]]
 name = "frame-benchmarking"
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -5228,7 +5228,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -5256,7 +5256,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -5277,7 +5277,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-curve25519"
 version = "1.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "curve25519-dalek 4.0.0-pre.1",
  "fp-evm",
@@ -5290,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-ed25519"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "ed25519-dalek",
  "fp-evm",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "num",
@@ -5325,7 +5325,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#37f46511ec20705c7a2c425c2cd1f3eeb6648495"
+source = "git+https://github.com/edgeware-network/frontier?branch=erup-5#dd513997543759e47f7286bd547c449b2459b7f6"
 dependencies = [
  "fp-evm",
  "ripemd160",
@@ -9346,7 +9346,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -9452,7 +9452,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 /// Block authoring scheme to be used by the dev service.
 #[derive(Debug)]
@@ -42,10 +42,14 @@ impl FromStr for Sealing {
 	}
 }
 
+/// Ethereum API Features
 #[derive(Debug, PartialEq, Clone)]
 pub enum EthApi {
+	/// Transactions Pool
 	Txpool,
+	/// Debugging
 	Debug,
+	/// Tracing.
 	Trace,
 }
 
@@ -59,6 +63,16 @@ impl FromStr for EthApi {
 			"trace" => Self::Trace,
 			_ => return Err(format!("`{}` is not recognized as a supported Ethereum Api", s)),
 		})
+	}
+}
+
+impl fmt::Display for EthApi {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			EthApi::Txpool => write!(f, "txpool"),
+			EthApi::Debug => write!(f, "debug"),
+			EthApi::Trace => write!(f, "trace"),
+		}
 	}
 }
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -107,7 +107,7 @@ edgeware-rpc-trace = { path = "../../client/rpc/trace", default-features = false
 # CLI-specific dependencies
 sc-cli = { git = "https://github.com/edgeware-network/substrate", branch = "erup-5", optional = true }
 frame-benchmarking-cli = { git = "https://github.com/edgeware-network/substrate", branch = "erup-5", optional = true }
-edgeware-cli-opt = { path = "../cli-opt", optional = true }
+edgeware-cli-opt = { package = "edgeware-cli-opt", path = "../cli-opt", optional = true }
 
 fc-consensus = { default-features = false, git = "https://github.com/edgeware-network/frontier", branch = "erup-5" }
 fp-consensus = { default-features = false, git = "https://github.com/edgeware-network/frontier", branch = "erup-5" }
@@ -149,6 +149,7 @@ frame-benchmarking-cli = { git = "https://github.com/edgeware-network/substrate"
 substrate-build-script-utils = { git = "https://github.com/edgeware-network/substrate", branch = "erup-5", optional = true }
 substrate-frame-cli = { git = "https://github.com/edgeware-network/substrate", branch = "erup-5", optional = true }
 sc-cli = { git = "https://github.com/edgeware-network/substrate", branch = "erup-5", optional = true }
+edgeware-cli-opt = { package = "edgeware-cli-opt", path = "../cli-opt", optional = true }
 
 [features]
 default = [ "cli" ]

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -164,13 +164,14 @@ pub fn testnet_genesis(
 ) -> GenesisConfig {
 	let alice_evm_account_id = H160::from_str("19e7e376e7c213b7e7e7e46cc70a5dd086daff2a").unwrap();
 	let mut evm_accounts = BTreeMap::new();
-	evm_accounts.insert(alice_evm_account_id, pallet_evm::GenesisAccount {
-		nonce: 0u32.into(),
-		balance: U256::from(123456_123_000_000_000_000_000u128),
-		storage: BTreeMap::new(),
-		code: vec![],
-	});
-
+	if create_evm_alice {
+		evm_accounts.insert(alice_evm_account_id, pallet_evm::GenesisAccount {
+			nonce: 0u32.into(),
+			balance: U256::from(123456_123_000_000_000_000_000u128),
+			storage: BTreeMap::new(),
+			code: vec![],
+		});
+	}
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
 			get_account_id_from_seed::<sr25519::Public>("Alice"),

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -16,42 +16,7 @@
 
 use sc_cli::{KeySubcommand, SignCmd, VanityCmd, VerifyCmd};
 use structopt::StructOpt;
-
-use std::{fmt, str::FromStr};
-
-/// Ethereum API Features
-#[derive(Debug, PartialEq, Clone)]
-pub enum EthApi {
-	/// Transactions Pool
-	Txpool,
-	/// Debugging
-	Debug,
-	/// Tracing.
-	Trace,
-}
-
-impl FromStr for EthApi {
-	type Err = String;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Ok(match s {
-			"txpool" => Self::Txpool,
-			"debug" => Self::Debug,
-			"trace" => Self::Trace,
-			_ => return Err(format!("`{}` is not recognized as a supported Ethereum Api", s)),
-		})
-	}
-}
-
-impl fmt::Display for EthApi {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match self {
-			EthApi::Txpool => write!(f, "txpool"),
-			EthApi::Debug => write!(f, "debug"),
-			EthApi::Trace => write!(f, "trace"),
-		}
-	}
-}
+use edgeware_cli_opt::EthApi;
 
 #[allow(missing_docs)]
 #[derive(Debug, StructOpt)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -15,9 +15,9 @@
 // along with Edgeware.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{chain_spec, service, service::new_partial, Cli, Subcommand};
-use edgeware_cli_opt::{RpcConfig, EthApi};
+use edgeware_cli_opt::RpcConfig;
 use edgeware_runtime::Block;
-use sc_cli::{ChainSpec, Result, Role, RuntimeVersion, SubstrateCli};
+use sc_cli::{ChainSpec, Result, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
@@ -156,13 +156,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(&cli.run.base)?;
 
 			let rpc_config = RpcConfig {
-				ethapi: cli.run.ethapi.iter().map(|api| {
-					match api {
-						Txpool => edgeware_cli_opt::EthApi::Txpool,
-						Debug => edgeware_cli_opt::EthApi::Debug,
-						Trace => edgeware_cli_opt::EthApi::Trace,
-					}
-				}).collect(),
+				ethapi: cli.run.ethapi.clone(),
 				ethapi_max_permits: cli.run.ethapi_max_permits,
 				ethapi_trace_max_count: cli.run.ethapi_trace_max_count,
 				ethapi_trace_cache_duration: cli.run.ethapi_trace_cache_duration,

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -30,10 +30,7 @@
 #![warn(missing_docs)]
 
 use edgeware_cli_opt::EthApi as EthApiCmd;
-use edgeware_primitives::{AccountId, Balance, Block, BlockNumber, Hash, Index};
-use edgeware_rpc_debug::{Debug, DebugHandler, DebugRequester, DebugServer};
-use edgeware_rpc_primitives_debug::DebugRuntimeApi;
-use edgeware_rpc_trace::{CacheRequester as TraceFilterCacheRequester, CacheTask, Trace, TraceServer};
+use edgeware_primitives::{AccountId, Balance, Block, BlockNumber, Hash};
 use edgeware_rpc_txpool::{TxPool, TxPoolServer};
 use fc_mapping_sync::{MappingSyncWorker, SyncStrategy};
 use fc_rpc::{
@@ -64,12 +61,12 @@ use sp_consensus::SelectChain;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
-use tokio::sync::Semaphore;
 
 /// RPC Client
 pub mod client;
 use client::RuntimeApiCollection;
 
+///
 pub mod tracing;
 
 /// Public io handler for exporting into other modules
@@ -282,11 +279,17 @@ where
 	io
 }
 
+///
 pub struct SpawnTasksParams<'a, B: BlockT, C, BE> {
+	///
 	pub task_manager: &'a TaskManager,
+	///
 	pub client: Arc<C>,
+	///
 	pub substrate_backend: Arc<BE>,
+	///
 	pub frontier_backend: Arc<fc_db::Backend<B>>,
+	///
 	pub filter_pool: Option<FilterPool>,
 }
 

--- a/node/rpc/src/tracing.rs
+++ b/node/rpc/src/tracing.rs
@@ -21,11 +21,15 @@ use edgeware_rpc_trace::{CacheRequester as TraceFilterCacheRequester, CacheTask,
 use tokio::sync::Semaphore;
 
 #[derive(Clone)]
+/// RPC requesters
 pub struct RpcRequesters {
+	/// Debug requester
 	pub debug: Option<DebugRequester>,
+	/// Trace requester
 	pub trace: Option<TraceFilterCacheRequester>,
 }
 
+/// Adds tracing functionality.
 pub fn extend_with_tracing<C, BE>(
 	client: Arc<C>,
 	requesters: RpcRequesters,
@@ -54,7 +58,7 @@ pub fn extend_with_tracing<C, BE>(
 	}
 }
 
-// Spawn the tasks that are required to run a Moonbeam tracing node.
+/// Spawn the tasks that are required to run a Moonbeam tracing node.
 pub fn spawn_tracing_tasks<B, C, BE>(
 	rpc_config: &edgeware_cli_opt::RpcConfig,
 	params: SpawnTasksParams<B, C, BE>,

--- a/node/runtime/src/precompiles.rs
+++ b/node/runtime/src/precompiles.rs
@@ -5,7 +5,6 @@ use sp_std::marker::PhantomData;
 use pallet_evm_precompile_blake2::Blake2F;
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_curve25519::{Curve25519Add, Curve25519ScalarMul};
-use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_ed25519::Ed25519Verify;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;

--- a/primitives/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/rpc/evm-tracing-events/src/runtime.rs
@@ -16,7 +16,10 @@
 
 extern crate alloc;
 
-use super::{opcodes_string, Context};
+#[cfg(feature = "evm-tracing")]
+use super::opcodes_string;
+
+use super::Context;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};


### PR DESCRIPTION
+ Reverted the bonding duration to 2 weeks (was changed to 24 weeks)
+ Reverted slah duration to 1 week (was changed to 6 weeks)
+ Changed the vote locking period back to 1 week. This one was changed from 1 week to 1 day on last upgrade, as an unwanted result of changing the voting enactment time. The change is probably uncontroversial (the parameters now just don't make sense), but would need to be mentioned when deploying launching the upgrade for good order.
+ Reverted GAS_PER_SECOND to 8_000_000, which was the previous value intended for mainnet instead of 40_000_000. The EVM is untested in production and there isn't much value in deploying with a massive gas capacity before getting any usage. We can scale this number up as we get more confident over time.
+ Removed the dumplicate definition of EthApi.There were two identical enum definitions in different files, with one mapping all elements to the other on funcction call to avoid type mismatch. Why it was done that way is a mystery, but functionalities shouldn't be affected by the change. It needs to be tested for good order.