### PR TITLE
v4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "beefy-primitives"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1553,7 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
- "sc-consensus-aura 0.10.0-dev (git+https://github.com/edgeware-network/edg-aura)",
+ "sc-consensus-aura",
  "sc-consensus-epochs",
  "sc-consensus-slots",
  "sc-finality-grandpa",
@@ -1673,7 +1687,7 @@ dependencies = [
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
  "sc-client-api",
- "sc-consensus-aura 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19)",
+ "sc-consensus-aura",
  "sc-consensus-epochs",
  "sc-consensus-manual-seal",
  "sc-finality-grandpa",
@@ -5239,6 +5253,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-babe"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-consensus-vrf",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
@@ -7266,16 +7304,20 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
  "log",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-slots",
+ "sc-keystore",
+ "sc-network",
+ "sc-network-test",
+ "sc-service",
  "sc-telemetry",
  "sp-api",
  "sp-application-crypto",
@@ -7286,38 +7328,14 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
+ "sp-keyring",
  "sp-keystore",
  "sp-runtime",
+ "sp-timestamp",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
- "thiserror",
-]
-
-[[package]]
-name = "sc-consensus-aura"
-version = "0.10.0-dev"
-source = "git+https://github.com/edgeware-network/edg-aura#c92b1fab4ea61232841710f7ac275cdb963a51c2"
-dependencies = [
- "async-trait",
- "futures 0.3.21",
- "log",
- "parity-scale-codec",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sc-consensus-slots",
- "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-test-runtime-client",
+ "tempfile",
  "thiserror",
 ]
 
@@ -7380,7 +7398,6 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7390,9 +7407,10 @@ dependencies = [
  "jsonrpc-derive",
  "log",
  "parity-scale-codec",
+ "sc-basic-authorship",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-aura 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19)",
+ "sc-consensus-aura",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-transaction-pool",
@@ -7410,7 +7428,10 @@ dependencies = [
  "sp-runtime",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
+ "substrate-test-runtime-client",
+ "substrate-test-runtime-transaction-pool",
  "thiserror",
+ "tokio 1.19.2",
 ]
 
 [[package]]
@@ -7676,6 +7697,34 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
+]
+
+[[package]]
+name = "sc-network-test"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures 0.3.21",
+ "futures-timer",
+ "libp2p",
+ "log",
+ "parking_lot 0.12.1",
+ "rand 0.7.3",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-network",
+ "sc-service",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-runtime",
+ "sp-tracing",
+ "substrate-test-runtime",
+ "substrate-test-runtime-client",
 ]
 
 [[package]]
@@ -9301,6 +9350,110 @@ dependencies = [
  "prometheus",
  "thiserror",
  "tokio 1.19.2",
+]
+
+[[package]]
+name = "substrate-test-client"
+version = "2.0.1"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "async-trait",
+ "futures 0.3.21",
+ "hex 0.4.3",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-offchain",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+]
+
+[[package]]
+name = "substrate-test-runtime"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "beefy-primitives",
+ "cfg-if 1.0.0",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "log",
+ "memory-db",
+ "pallet-babe",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "sc-service",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-externalities",
+ "sp-finality-grandpa",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-session",
+ "sp-state-machine",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "trie-db",
+]
+
+[[package]]
+name = "substrate-test-runtime-client"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "futures 0.3.21",
+ "parity-scale-codec",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "substrate-test-client",
+ "substrate-test-runtime",
+]
+
+[[package]]
+name = "substrate-test-runtime-transaction-pool"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "futures 0.3.21",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "sp-blockchain",
+ "sp-runtime",
+ "substrate-test-runtime-client",
+ "thiserror",
 ]
 
 [[package]]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -64,7 +64,7 @@ sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "pol
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
-sc-consensus-aura = { git = "https://github.com/edgeware-network/edg-aura", default-features = false }
+sc-consensus-aura = { path = "../consensus-transition/aura", default-features = false }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-consensus-slots =  { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
@@ -178,4 +178,7 @@ runtime-benchmarks = [
 ]
 fast-runtime = [
 	"edgeware-runtime/fast-runtime",
+]
+beresheet-runtime = [
+	"edgeware-runtime/beresheet-runtime",
 ]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -25,7 +25,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn impl_version() -> String {
-		"4.0.0".into()
+		"4.0.1".into()
 	}
 
 	fn description() -> String {

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -265,7 +265,7 @@ pub fn new_partial(
 		    check_for_equivocation: Default::default(),
 		    telemetry: telemetry.as_ref().map(|x| x.handle()),
 		    #[cfg(feature = "beresheet-runtime")]
-			compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(1888u32) },
+			compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(8888u32) },
 		    #[cfg(not(feature = "beresheet-runtime"))]
 			compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(14_555_555u32) },
 		}
@@ -554,7 +554,7 @@ pub fn new_full_base(mut config: Configuration,
 				max_block_proposal_slot_portion: None,
 				telemetry: telemetry.as_ref().map(|x| x.handle()),
 				#[cfg(feature = "beresheet-runtime")]
-				compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(1888u32) },
+				compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(8888u32) },
 				#[cfg(not(feature = "beresheet-runtime"))]
 				compatibility_mode: CompatibilityMode::UseInitializeBlock { until: BlockNumber::from(14_555_555u32) },
 			},

--- a/node/consensus-transition/aura/Cargo.toml
+++ b/node/consensus-transition/aura/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "sc-consensus-aura"
+version = "0.10.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Aura consensus algorithm for substrate"
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+thiserror = "1.0"
+futures = "0.3.21"
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+log = "0.4.8"
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+async-trait = "0.1.50"
+
+[dev-dependencies]
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+sc-network-test = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
+tempfile = "3.1.0"
+parking_lot = "0.12.0"

--- a/node/consensus-transition/aura/src/import_queue.rs
+++ b/node/consensus-transition/aura/src/import_queue.rs
@@ -1,0 +1,441 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Module implementing the logic for verifying and importing AuRa blocks.
+
+use crate::{
+	aura_err, authorities, find_pre_digest, slot_author, AuthorityId, CompatibilityMode, Error,
+};
+use codec::{Codec, Decode, Encode};
+use log::{debug, info, trace};
+use prometheus_endpoint::Registry;
+use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
+use sc_consensus::{
+	block_import::{BlockImport, BlockImportParams, ForkChoiceStrategy},
+	import_queue::{BasicQueue, BoxJustificationImport, DefaultImportQueue, Verifier},
+};
+use sc_consensus_slots::{check_equivocation, CheckedHeader, InherentDataProviderExt};
+use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
+use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_block_builder::BlockBuilder as BlockBuilderApi;
+use sp_blockchain::{well_known_cache_keys::Id as CacheKeyId, HeaderBackend};
+use sp_consensus::{CanAuthorWith, Error as ConsensusError};
+use sp_consensus_aura::{digests::CompatibleDigestItem, inherents::AuraInherentData, AuraApi};
+use sp_consensus_slots::Slot;
+use sp_core::{crypto::Pair, ExecutionContext};
+use sp_inherents::{CreateInherentDataProviders, InherentDataProvider as _};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Header, NumberFor},
+	DigestItem,
+};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+
+/// check a header has been signed by the right key. If the slot is too far in the future, an error
+/// will be returned. If it's successful, returns the pre-header and the digest item
+/// containing the seal.
+///
+/// This digest item will always return `Some` when used with `as_aura_seal`.
+fn check_header<C, B: BlockT, P: Pair>(
+	client: &C,
+	slot_now: Slot,
+	mut header: B::Header,
+	hash: B::Hash,
+	authorities: &[AuthorityId<P>],
+	check_for_equivocation: CheckForEquivocation,
+) -> Result<CheckedHeader<B::Header, (Slot, DigestItem)>, Error<B>>
+where
+	P::Signature: Codec,
+	C: sc_client_api::backend::AuxStore,
+	P::Public: Encode + Decode + PartialEq + Clone,
+{
+	let seal = header.digest_mut().pop().ok_or(Error::HeaderUnsealed(hash))?;
+
+	let sig = seal.as_aura_seal().ok_or_else(|| aura_err(Error::HeaderBadSeal(hash)))?;
+
+	let slot = find_pre_digest::<B, P::Signature>(&header)?;
+
+	if slot > slot_now {
+		header.digest_mut().push(seal);
+		Ok(CheckedHeader::Deferred(header, slot))
+	} else {
+		// check the signature is valid under the expected authority and
+		// chain state.
+		let expected_author =
+			slot_author::<P>(slot, authorities).ok_or(Error::SlotAuthorNotFound)?;
+
+		let pre_hash = header.hash();
+
+		if P::verify(&sig, pre_hash.as_ref(), expected_author) {
+			if check_for_equivocation.check_for_equivocation() {
+				if let Some(equivocation_proof) =
+					check_equivocation(client, slot_now, slot, &header, expected_author)
+						.map_err(Error::Client)?
+				{
+					info!(
+						target: "aura",
+						"Slot author is equivocating at slot {} with headers {:?} and {:?}",
+						slot,
+						equivocation_proof.first_header.hash(),
+						equivocation_proof.second_header.hash(),
+					);
+				}
+			}
+
+			Ok(CheckedHeader::Checked(header, (slot, seal)))
+		} else {
+			Err(Error::BadSignature(hash))
+		}
+	}
+}
+
+/// A verifier for Aura blocks.
+pub struct AuraVerifier<C, P, CAW, CIDP, N> {
+	client: Arc<C>,
+	phantom: PhantomData<P>,
+	create_inherent_data_providers: CIDP,
+	can_author_with: CAW,
+	check_for_equivocation: CheckForEquivocation,
+	telemetry: Option<TelemetryHandle>,
+	compatibility_mode: CompatibilityMode<N>,
+}
+
+impl<C, P, CAW, CIDP, N> AuraVerifier<C, P, CAW, CIDP, N> {
+	pub(crate) fn new(
+		client: Arc<C>,
+		create_inherent_data_providers: CIDP,
+		can_author_with: CAW,
+		check_for_equivocation: CheckForEquivocation,
+		telemetry: Option<TelemetryHandle>,
+		compatibility_mode: CompatibilityMode<N>,
+	) -> Self {
+		Self {
+			client,
+			create_inherent_data_providers,
+			can_author_with,
+			check_for_equivocation,
+			telemetry,
+			compatibility_mode,
+			phantom: PhantomData,
+		}
+	}
+}
+
+impl<C, P, CAW, CIDP, N> AuraVerifier<C, P, CAW, CIDP, N>
+where
+	P: Send + Sync + 'static,
+	CAW: Send + Sync + 'static,
+	CIDP: Send,
+{
+	async fn check_inherents<B: BlockT>(
+		&self,
+		block: B,
+		block_id: BlockId<B>,
+		inherent_data: sp_inherents::InherentData,
+		create_inherent_data_providers: CIDP::InherentDataProviders,
+		execution_context: ExecutionContext,
+	) -> Result<(), Error<B>>
+	where
+		C: ProvideRuntimeApi<B>,
+		C::Api: BlockBuilderApi<B>,
+		CAW: CanAuthorWith<B>,
+		CIDP: CreateInherentDataProviders<B, ()>,
+	{
+		if let Err(e) = self.can_author_with.can_author_with(&block_id) {
+			debug!(
+				target: "aura",
+				"Skipping `check_inherents` as authoring version is not compatible: {}",
+				e,
+			);
+
+			return Ok(())
+		}
+
+		let inherent_res = self
+			.client
+			.runtime_api()
+			.check_inherents_with_context(&block_id, execution_context, block, inherent_data)
+			.map_err(|e| Error::Client(e.into()))?;
+
+		if !inherent_res.ok() {
+			for (i, e) in inherent_res.into_errors() {
+				match create_inherent_data_providers.try_handle_error(&i, &e).await {
+					Some(res) => res.map_err(Error::Inherent)?,
+					None => return Err(Error::UnknownInherentError(i)),
+				}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP, NumberFor<B>>
+where
+	C: ProvideRuntimeApi<B> + Send + Sync + sc_client_api::backend::AuxStore + BlockOf,
+	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B>,
+	P: Pair + Send + Sync + 'static,
+	P::Public: Send + Sync + Hash + Eq + Clone + Decode + Encode + Debug + 'static,
+	P::Signature: Encode + Decode,
+	CAW: CanAuthorWith<B> + Send + Sync + 'static,
+	CIDP: CreateInherentDataProviders<B, ()> + Send + Sync,
+	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
+{
+	async fn verify(
+		&mut self,
+		mut block: BlockImportParams<B, ()>,
+	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		let hash = block.header.hash();
+		let parent_hash = *block.header.parent_hash();
+		let authorities = authorities(
+			self.client.as_ref(),
+			parent_hash,
+			*block.header.number(),
+			&self.compatibility_mode,
+		)
+		.map_err(|e| format!("Could not fetch authorities at {:?}: {}", parent_hash, e))?;
+
+		let create_inherent_data_providers = self
+			.create_inherent_data_providers
+			.create_inherent_data_providers(parent_hash, ())
+			.await
+			.map_err(|e| Error::<B>::Client(sp_blockchain::Error::Application(e)))?;
+
+		let mut inherent_data = create_inherent_data_providers
+			.create_inherent_data()
+			.map_err(Error::<B>::Inherent)?;
+
+		let slot_now = create_inherent_data_providers.slot();
+
+		// we add one to allow for some small drift.
+		// FIXME #1019 in the future, alter this queue to allow deferring of
+		// headers
+		let checked_header = check_header::<C, B, P>(
+			&self.client,
+			slot_now + 1,
+			block.header,
+			hash,
+			&authorities[..],
+			self.check_for_equivocation,
+		)
+		.map_err(|e| e.to_string())?;
+		match checked_header {
+			CheckedHeader::Checked(pre_header, (slot, seal)) => {
+				// if the body is passed through, we need to use the runtime
+				// to check that the internally-set timestamp in the inherents
+				// actually matches the slot set in the seal.
+				if let Some(inner_body) = block.body.take() {
+					let new_block = B::new(pre_header.clone(), inner_body);
+
+					inherent_data.aura_replace_inherent_data(slot);
+
+					// skip the inherents verification if the runtime API is old.
+					if self
+						.client
+						.runtime_api()
+						.has_api_with::<dyn BlockBuilderApi<B>, _>(
+							&BlockId::Hash(parent_hash),
+							|v| v >= 2,
+						)
+						.map_err(|e| e.to_string())?
+					{
+						self.check_inherents(
+							new_block.clone(),
+							BlockId::Hash(parent_hash),
+							inherent_data,
+							create_inherent_data_providers,
+							block.origin.into(),
+						)
+						.await
+						.map_err(|e| e.to_string())?;
+					}
+
+					let (_, inner_body) = new_block.deconstruct();
+					block.body = Some(inner_body);
+				}
+
+				trace!(target: "aura", "Checked {:?}; importing.", pre_header);
+				telemetry!(
+					self.telemetry;
+					CONSENSUS_TRACE;
+					"aura.checked_and_importing";
+					"pre_header" => ?pre_header,
+				);
+
+				block.header = pre_header;
+				block.post_digests.push(seal);
+				block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+				block.post_hash = Some(hash);
+
+				Ok((block, None))
+			},
+			CheckedHeader::Deferred(a, b) => {
+				debug!(target: "aura", "Checking {:?} failed; {:?}, {:?}.", hash, a, b);
+				telemetry!(
+					self.telemetry;
+					CONSENSUS_DEBUG;
+					"aura.header_too_far_in_future";
+					"hash" => ?hash,
+					"a" => ?a,
+					"b" => ?b,
+				);
+				Err(format!("Header {:?} rejected: too far in the future", hash))
+			},
+		}
+	}
+}
+
+/// Should we check for equivocation of a block author?
+#[derive(Debug, Clone, Copy)]
+pub enum CheckForEquivocation {
+	/// Yes, check for equivocation.
+	///
+	/// This is the default setting for this.
+	Yes,
+	/// No, don't check for equivocation.
+	No,
+}
+
+impl CheckForEquivocation {
+	/// Should we check for equivocation?
+	fn check_for_equivocation(self) -> bool {
+		matches!(self, Self::Yes)
+	}
+}
+
+impl Default for CheckForEquivocation {
+	fn default() -> Self {
+		Self::Yes
+	}
+}
+
+/// Parameters of [`import_queue`].
+pub struct ImportQueueParams<'a, Block: BlockT, I, C, S, CAW, CIDP> {
+	/// The block import to use.
+	pub block_import: I,
+	/// The justification import.
+	pub justification_import: Option<BoxJustificationImport<Block>>,
+	/// The client to interact with the chain.
+	pub client: Arc<C>,
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+	/// The spawner to spawn background tasks.
+	pub spawner: &'a S,
+	/// The prometheus registry.
+	pub registry: Option<&'a Registry>,
+	/// Can we author with the current node?
+	pub can_author_with: CAW,
+	/// Should we check for equivocation?
+	pub check_for_equivocation: CheckForEquivocation,
+	/// Telemetry instance used to report telemetry metrics.
+	pub telemetry: Option<TelemetryHandle>,
+	/// Compatibility mode that should be used.
+	///
+	/// If in doubt, use `Default::default()`.
+	pub compatibility_mode: CompatibilityMode<NumberFor<Block>>,
+}
+
+/// Start an import queue for the Aura consensus algorithm.
+pub fn import_queue<P, Block, I, C, S, CAW, CIDP>(
+	ImportQueueParams {
+		block_import,
+		justification_import,
+		client,
+		create_inherent_data_providers,
+		spawner,
+		registry,
+		can_author_with,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	}: ImportQueueParams<Block, I, C, S, CAW, CIDP>,
+) -> Result<DefaultImportQueue<Block, C>, sp_consensus::Error>
+where
+	Block: BlockT,
+	C::Api: BlockBuilderApi<Block> + AuraApi<Block, AuthorityId<P>> + ApiExt<Block>,
+	C: 'static
+		+ ProvideRuntimeApi<Block>
+		+ BlockOf
+		+ Send
+		+ Sync
+		+ AuxStore
+		+ UsageProvider<Block>
+		+ HeaderBackend<Block>,
+	I: BlockImport<Block, Error = ConsensusError, Transaction = sp_api::TransactionFor<C, Block>>
+		+ Send
+		+ Sync
+		+ 'static,
+	P: Pair + Send + Sync + 'static,
+	P::Public: Clone + Eq + Send + Sync + Hash + Debug + Encode + Decode,
+	P::Signature: Encode + Decode,
+	S: sp_core::traits::SpawnEssentialNamed,
+	CAW: CanAuthorWith<Block> + Send + Sync + 'static,
+	CIDP: CreateInherentDataProviders<Block, ()> + Sync + Send + 'static,
+	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
+{
+	let verifier = build_verifier::<P, _, _, _, _>(BuildVerifierParams {
+		client,
+		create_inherent_data_providers,
+		can_author_with,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	});
+
+	Ok(BasicQueue::new(verifier, Box::new(block_import), justification_import, spawner, registry))
+}
+
+/// Parameters of [`build_verifier`].
+pub struct BuildVerifierParams<C, CIDP, CAW, N> {
+	/// The client to interact with the chain.
+	pub client: Arc<C>,
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+	/// Can we author with the current node?
+	pub can_author_with: CAW,
+	/// Should we check for equivocation?
+	pub check_for_equivocation: CheckForEquivocation,
+	/// Telemetry instance used to report telemetry metrics.
+	pub telemetry: Option<TelemetryHandle>,
+	/// Compatibility mode that should be used.
+	///
+	/// If in doubt, use `Default::default()`.
+	pub compatibility_mode: CompatibilityMode<N>,
+}
+
+/// Build the [`AuraVerifier`]
+pub fn build_verifier<P, C, CIDP, CAW, N>(
+	BuildVerifierParams {
+		client,
+		create_inherent_data_providers,
+		can_author_with,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	}: BuildVerifierParams<C, CIDP, CAW, N>,
+) -> AuraVerifier<C, P, CAW, CIDP, N> {
+	AuraVerifier::<_, P, _, _, _>::new(
+		client,
+		create_inherent_data_providers,
+		can_author_with,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	)
+}

--- a/node/consensus-transition/aura/src/lib.rs
+++ b/node/consensus-transition/aura/src/lib.rs
@@ -1,0 +1,630 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Aura (Authority-round) consensus in substrate.
+//!
+//! Aura works by having a list of authorities A who are expected to roughly
+//! agree on the current time. Time is divided up into discrete slots of t
+//! seconds each. For each slot s, the author of that slot is A[s % |A|].
+//!
+//! The author is allowed to issue one block but not more during that slot,
+//! and it will be built upon the longest valid chain that has been seen.
+//!
+//! Blocks from future steps will be either deferred or rejected depending on how
+//! far in the future they are.
+//!
+//! NOTE: Aura itself is designed to be generic over the crypto used.
+#![forbid(missing_docs, unsafe_code)]
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, pin::Pin, sync::Arc};
+
+use futures::prelude::*;
+use log::{debug, trace};
+
+use codec::{Codec, Decode, Encode};
+
+use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
+use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy, StateAction};
+use sc_consensus_slots::{
+	BackoffAuthoringBlocksStrategy, InherentDataProviderExt, SimpleSlotWorkerToSlotWorker,
+	SlotInfo, StorageChanges,
+};
+use sc_telemetry::TelemetryHandle;
+use sp_api::{Core, ProvideRuntimeApi};
+use sp_application_crypto::{AppKey, AppPublic};
+use sp_blockchain::{HeaderBackend, Result as CResult};
+use sp_consensus::{
+	BlockOrigin, CanAuthorWith, Environment, Error as ConsensusError, Proposer, SelectChain,
+};
+use sp_consensus_slots::Slot;
+use sp_core::crypto::{ByteArray, Pair, Public};
+use sp_inherents::CreateInherentDataProviders;
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Header, Member, NumberFor, Zero},
+	DigestItem,
+};
+
+mod import_queue;
+
+pub use import_queue::{
+	build_verifier, import_queue, AuraVerifier, BuildVerifierParams, CheckForEquivocation,
+	ImportQueueParams,
+};
+pub use sc_consensus_slots::SlotProportion;
+pub use sp_consensus::SyncOracle;
+pub use sp_consensus_aura::{
+	digests::CompatibleDigestItem,
+	inherents::{InherentDataProvider, InherentType as AuraInherent, INHERENT_IDENTIFIER},
+	AuraApi, ConsensusLog, SlotDuration, AURA_ENGINE_ID,
+};
+
+type AuthorityId<P> = <P as Pair>::Public;
+
+/// Run `AURA` in a compatibility mode.
+///
+/// This is required for when the chain was launched and later there
+/// was a consensus breaking change.
+#[derive(Debug, Clone)]
+pub enum CompatibilityMode<N> {
+	/// Don't use any compatibility mode.
+	None,
+	/// Call `initialize_block` before doing any runtime calls.
+	///
+	/// The node would execute `initialize_block` before fetchting the authorities
+	/// from the runtime. This behaviour changed in: <https://github.com/paritytech/substrate/pull/9132>
+	///
+	/// By calling `initialize_block` before fetching the authorities, on a block that
+	/// would enact a new validator set, the block would already be build/sealed by an
+	/// authority of the new set. A block that enacts a new set, should not be sealed/build
+	/// by an authority of the new set. This isn't done anymore. However, to make new nodes
+	/// being able to sync the old chain this compatibility mode exists.
+	UseInitializeBlock {
+		/// The block number until this compatibility mode should be executed. The first runtime
+		/// call in the context (importing it/building it) of the `until` block should disable the
+		/// compatibility mode. This number should be of a block in the future! It should be a
+		/// block number on that all nodes have upgraded to a release that runs with the
+		/// compatibility mode. After this block there will be a hard fork when the authority set
+		/// changes, between the old nodes (running with `initialize_block`) and the new nodes.
+		until: N,
+	},
+}
+
+impl<N> Default for CompatibilityMode<N> {
+	fn default() -> Self {
+		Self::None
+	}
+}
+
+/// Get the slot duration for Aura.
+pub fn slot_duration<A, B, C>(client: &C) -> CResult<SlotDuration>
+where
+	A: Codec,
+	B: BlockT,
+	C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
+	C::Api: AuraApi<B, A>,
+{
+	let best_block_id = BlockId::Hash(client.usage_info().chain.best_hash);
+	client.runtime_api().slot_duration(&best_block_id).map_err(|err| err.into())
+}
+
+/// Get slot author for given block along with authorities.
+fn slot_author<P: Pair>(slot: Slot, authorities: &[AuthorityId<P>]) -> Option<&AuthorityId<P>> {
+	if authorities.is_empty() {
+		return None
+	}
+
+	let idx = *slot % (authorities.len() as u64);
+	assert!(
+		idx <= usize::MAX as u64,
+		"It is impossible to have a vector with length beyond the address space; qed",
+	);
+
+	let current_author = authorities.get(idx as usize).expect(
+		"authorities not empty; index constrained to list length;this is a valid index; qed",
+	);
+
+	Some(current_author)
+}
+
+/// Parameters of [`start_aura`].
+pub struct StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, CAW, N> {
+	/// The duration of a slot.
+	pub slot_duration: SlotDuration,
+	/// The client to interact with the chain.
+	pub client: Arc<C>,
+	/// A select chain implementation to select the best block.
+	pub select_chain: SC,
+	/// The block import.
+	pub block_import: I,
+	/// The proposer factory to build proposer instances.
+	pub proposer_factory: PF,
+	/// The sync oracle that can give us the current sync status.
+	pub sync_oracle: SO,
+	/// Hook into the sync module to control the justification sync process.
+	pub justification_sync_link: L,
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+	/// Should we force the authoring of blocks?
+	pub force_authoring: bool,
+	/// The backoff strategy when we miss slots.
+	pub backoff_authoring_blocks: Option<BS>,
+	/// The keystore used by the node.
+	pub keystore: SyncCryptoStorePtr,
+	/// Can we author a block with this node?
+	pub can_author_with: CAW,
+	/// The proportion of the slot dedicated to proposing.
+	///
+	/// The block proposing will be limited to this proportion of the slot from the starting of the
+	/// slot. However, the proposing can still take longer when there is some lenience factor
+	/// applied, because there were no blocks produced for some slots.
+	pub block_proposal_slot_portion: SlotProportion,
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied
+	/// due to no blocks being produced.
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
+	/// Telemetry instance used to report telemetry metrics.
+	pub telemetry: Option<TelemetryHandle>,
+	/// Compatibility mode that should be used.
+	///
+	/// If in doubt, use `Default::default()`.
+	pub compatibility_mode: CompatibilityMode<N>,
+}
+
+/// Start the aura worker. The returned future should be run in a futures executor.
+pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, CAW, Error>(
+	StartAuraParams {
+		slot_duration,
+		client,
+		select_chain,
+		block_import,
+		proposer_factory,
+		sync_oracle,
+		justification_sync_link,
+		create_inherent_data_providers,
+		force_authoring,
+		backoff_authoring_blocks,
+		keystore,
+		can_author_with,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		telemetry,
+		compatibility_mode,
+	}: StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, CAW, NumberFor<B>>,
+) -> Result<impl Future<Output = ()>, sp_consensus::Error>
+where
+	P: Pair + Send + Sync,
+	P::Public: AppPublic + Hash + Member + Encode + Decode,
+	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	SC: SelectChain<B>,
+	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
+	PF: Environment<B, Error = Error> + Send + Sync + 'static,
+	PF::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
+	SO: SyncOracle + Send + Sync + Clone,
+	L: sc_consensus::JustificationSyncLink<B>,
+	CIDP: CreateInherentDataProviders<B, ()> + Send,
+	CIDP::InherentDataProviders: InherentDataProviderExt + Send,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+	CAW: CanAuthorWith<B> + Send,
+	Error: std::error::Error + Send + From<sp_consensus::Error> + 'static,
+{
+	let worker = build_aura_worker::<P, _, _, _, _, _, _, _, _>(BuildAuraWorkerParams {
+		client,
+		block_import,
+		proposer_factory,
+		keystore,
+		sync_oracle: sync_oracle.clone(),
+		justification_sync_link,
+		force_authoring,
+		backoff_authoring_blocks,
+		telemetry,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		compatibility_mode,
+	});
+
+	Ok(sc_consensus_slots::start_slot_worker(
+		slot_duration,
+		select_chain,
+		worker,
+		sync_oracle,
+		create_inherent_data_providers,
+		can_author_with,
+	))
+}
+
+/// Parameters of [`build_aura_worker`].
+pub struct BuildAuraWorkerParams<C, I, PF, SO, L, BS, N> {
+	/// The client to interact with the chain.
+	pub client: Arc<C>,
+	/// The block import.
+	pub block_import: I,
+	/// The proposer factory to build proposer instances.
+	pub proposer_factory: PF,
+	/// The sync oracle that can give us the current sync status.
+	pub sync_oracle: SO,
+	/// Hook into the sync module to control the justification sync process.
+	pub justification_sync_link: L,
+	/// Should we force the authoring of blocks?
+	pub force_authoring: bool,
+	/// The backoff strategy when we miss slots.
+	pub backoff_authoring_blocks: Option<BS>,
+	/// The keystore used by the node.
+	pub keystore: SyncCryptoStorePtr,
+	/// The proportion of the slot dedicated to proposing.
+	///
+	/// The block proposing will be limited to this proportion of the slot from the starting of the
+	/// slot. However, the proposing can still take longer when there is some lenience factor
+	/// applied, because there were no blocks produced for some slots.
+	pub block_proposal_slot_portion: SlotProportion,
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied
+	/// due to no blocks being produced.
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
+	/// Telemetry instance used to report telemetry metrics.
+	pub telemetry: Option<TelemetryHandle>,
+	/// Compatibility mode that should be used.
+	///
+	/// If in doubt, use `Default::default()`.
+	pub compatibility_mode: CompatibilityMode<N>,
+}
+
+/// Build the aura worker.
+///
+/// The caller is responsible for running this worker, otherwise it will do nothing.
+pub fn build_aura_worker<P, B, C, PF, I, SO, L, BS, Error>(
+	BuildAuraWorkerParams {
+		client,
+		block_import,
+		proposer_factory,
+		sync_oracle,
+		justification_sync_link,
+		backoff_authoring_blocks,
+		keystore,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		telemetry,
+		force_authoring,
+		compatibility_mode,
+	}: BuildAuraWorkerParams<C, I, PF, SO, L, BS, NumberFor<B>>,
+) -> impl sc_consensus_slots::SlotWorker<B, <PF::Proposer as Proposer<B>>::Proof>
+
+where
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	PF: Environment<B, Error = Error> + Send + Sync + 'static,
+	PF::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
+	P: Pair + Send + Sync,
+	P::Public: AppPublic + Hash + Member + Encode + Decode,
+	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
+	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
+	Error: std::error::Error + Send + From<sp_consensus::Error> + 'static,
+	SO: SyncOracle + Send + Sync + Clone,
+	L: sc_consensus::JustificationSyncLink<B>,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+{
+	SimpleSlotWorkerToSlotWorker(AuraWorker {
+		client,
+		block_import,
+		env: proposer_factory,
+		keystore,
+		sync_oracle,
+		justification_sync_link,
+		force_authoring,
+		backoff_authoring_blocks,
+		telemetry,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		compatibility_mode,
+		_key_type: PhantomData::<P>,
+	})
+}
+
+struct AuraWorker<C, E, I, P, SO, L, BS, N> {
+	client: Arc<C>,
+	block_import: I,
+	env: E,
+	keystore: SyncCryptoStorePtr,
+	sync_oracle: SO,
+	justification_sync_link: L,
+	force_authoring: bool,
+	backoff_authoring_blocks: Option<BS>,
+	block_proposal_slot_portion: SlotProportion,
+	max_block_proposal_slot_portion: Option<SlotProportion>,
+	telemetry: Option<TelemetryHandle>,
+	compatibility_mode: CompatibilityMode<N>,
+	_key_type: PhantomData<P>,
+}
+
+#[async_trait::async_trait]
+impl<B, C, E, I, P, Error, SO, L, BS> sc_consensus_slots::SimpleSlotWorker<B>
+	for AuraWorker<C, E, I, P, SO, L, BS, NumberFor<B>>
+where
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + HeaderBackend<B> + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	E: Environment<B, Error = Error> + Send + Sync,
+	E::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
+	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
+	P: Pair + Send + Sync,
+	P::Public: AppPublic + Public + Member + Encode + Decode + Hash,
+	P::Signature: TryFrom<Vec<u8>> + Member + Encode + Decode + Hash + Debug,
+	SO: SyncOracle + Send + Clone + Sync,
+	L: sc_consensus::JustificationSyncLink<B>,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+	Error: std::error::Error + Send + From<sp_consensus::Error> + 'static,
+{
+	type BlockImport = I;
+	type SyncOracle = SO;
+	type JustificationSyncLink = L;
+	type CreateProposer =
+		Pin<Box<dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static>>;
+	type Proposer = E::Proposer;
+	type Claim = P::Public;
+	type EpochData = Vec<AuthorityId<P>>;
+
+	fn logging_target(&self) -> &'static str {
+		"aura"
+	}
+
+	fn block_import(&mut self) -> &mut Self::BlockImport {
+		&mut self.block_import
+	}
+
+	fn epoch_data(
+		&self,
+		header: &B::Header,
+		_slot: Slot,
+	) -> Result<Self::EpochData, sp_consensus::Error> {
+		authorities(
+			self.client.as_ref(),
+			header.hash(),
+			*header.number() + 1u32.into(),
+			&self.compatibility_mode,
+		)
+	}
+
+	fn authorities_len(&self, epoch_data: &Self::EpochData) -> Option<usize> {
+		Some(epoch_data.len())
+	}
+
+	async fn claim_slot(
+		&self,
+		_header: &B::Header,
+		slot: Slot,
+		epoch_data: &Self::EpochData,
+	) -> Option<Self::Claim> {
+		let expected_author = slot_author::<P>(slot, epoch_data);
+		expected_author.and_then(|p| {
+			if SyncCryptoStore::has_keys(
+				&*self.keystore,
+				&[(p.to_raw_vec(), sp_application_crypto::key_types::AURA)],
+			) {
+				Some(p.clone())
+			} else {
+				None
+			}
+		})
+	}
+
+	fn pre_digest_data(&self, slot: Slot, _claim: &Self::Claim) -> Vec<sp_runtime::DigestItem> {
+		vec![<DigestItem as CompatibleDigestItem<P::Signature>>::aura_pre_digest(slot)]
+	}
+
+	async fn block_import_params(
+		&self,
+		header: B::Header,
+		header_hash: &B::Hash,
+		body: Vec<B::Extrinsic>,
+		storage_changes: StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
+		public: Self::Claim,
+		_epoch: Self::EpochData,
+	) -> Result<
+		sc_consensus::BlockImportParams<B, <Self::BlockImport as BlockImport<B>>::Transaction>,
+		sp_consensus::Error,
+	> {
+		// sign the pre-sealed hash of the block and then
+		// add it to a digest item.
+		let public_type_pair = public.to_public_crypto_pair();
+		let public = public.to_raw_vec();
+		let signature = SyncCryptoStore::sign_with(
+			&*self.keystore,
+			<AuthorityId<P> as AppKey>::ID,
+			&public_type_pair,
+			header_hash.as_ref(),
+		)
+		.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+		.ok_or_else(|| {
+			sp_consensus::Error::CannotSign(
+				public.clone(),
+				"Could not find key in keystore.".into(),
+			)
+		})?;
+		let signature = signature
+			.clone()
+			.try_into()
+			.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
+
+		let signature_digest_item =
+			<DigestItem as CompatibleDigestItem<P::Signature>>::aura_seal(signature);
+
+		let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+		import_block.post_digests.push(signature_digest_item);
+		import_block.body = Some(body);
+		import_block.state_action =
+			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(storage_changes));
+		import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
+		Ok(import_block)
+	}
+
+	fn force_authoring(&self) -> bool {
+		self.force_authoring
+	}
+
+	fn should_backoff(&self, slot: Slot, chain_head: &B::Header) -> bool {
+		if let Some(ref strategy) = self.backoff_authoring_blocks {
+			if let Ok(chain_head_slot) = find_pre_digest::<B, P::Signature>(chain_head) {
+				return strategy.should_backoff(
+					*chain_head.number(),
+					chain_head_slot,
+					self.client.info().finalized_number,
+					slot,
+					self.logging_target(),
+				)
+			}
+		}
+		false
+	}
+
+	fn sync_oracle(&mut self) -> &mut Self::SyncOracle {
+		&mut self.sync_oracle
+	}
+
+	fn justification_sync_link(&mut self) -> &mut Self::JustificationSyncLink {
+		&mut self.justification_sync_link
+	}
+
+	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
+		self.env
+			.init(block)
+			.map_err(|e| sp_consensus::Error::ClientImport(format!("{:?}", e)))
+			.boxed()
+	}
+
+	fn telemetry(&self) -> Option<TelemetryHandle> {
+		self.telemetry.clone()
+	}
+
+	fn proposing_remaining_duration(&self, slot_info: &SlotInfo<B>) -> std::time::Duration {
+		let parent_slot = find_pre_digest::<B, P::Signature>(&slot_info.chain_head).ok();
+
+		sc_consensus_slots::proposing_remaining_duration(
+			parent_slot,
+			slot_info,
+			&self.block_proposal_slot_portion,
+			self.max_block_proposal_slot_portion.as_ref(),
+			sc_consensus_slots::SlotLenienceType::Exponential,
+			self.logging_target(),
+		)
+	}
+}
+
+fn aura_err<B: BlockT>(error: Error<B>) -> Error<B> {
+	debug!(target: "aura", "{}", error);
+	error
+}
+
+/// Aura Errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error<B: BlockT> {
+	/// Multiple Aura pre-runtime headers
+	#[error("Multiple Aura pre-runtime headers")]
+	MultipleHeaders,
+	/// No Aura pre-runtime digest found
+	#[error("No Aura pre-runtime digest found")]
+	NoDigestFound,
+	/// Header is unsealed
+	#[error("Header {0:?} is unsealed")]
+	HeaderUnsealed(B::Hash),
+	/// Header has a bad seal
+	#[error("Header {0:?} has a bad seal")]
+	HeaderBadSeal(B::Hash),
+	/// Slot Author not found
+	#[error("Slot Author not found")]
+	SlotAuthorNotFound,
+	/// Bad signature
+	#[error("Bad signature on {0:?}")]
+	BadSignature(B::Hash),
+	/// Client Error
+	#[error(transparent)]
+	Client(sp_blockchain::Error),
+	/// Unknown inherent error for identifier
+	#[error("Unknown inherent error for identifier: {}", String::from_utf8_lossy(.0))]
+	UnknownInherentError(sp_inherents::InherentIdentifier),
+	/// Inherents Error
+	#[error("Inherent error: {0}")]
+	Inherent(sp_inherents::Error),
+}
+
+impl<B: BlockT> From<Error<B>> for String {
+	fn from(error: Error<B>) -> String {
+		error.to_string()
+	}
+}
+
+/// Get pre-digests from the header
+pub fn find_pre_digest<B: BlockT, Signature: Codec>(header: &B::Header) -> Result<Slot, Error<B>> {
+	if header.number().is_zero() {
+		return Ok(0.into())
+	}
+
+	let mut pre_digest: Option<Slot> = None;
+	for log in header.digest().logs() {
+		trace!(target: "aura", "Checking log {:?}", log);
+		match (CompatibleDigestItem::<Signature>::as_aura_pre_digest(log), pre_digest.is_some()) {
+			(Some(_), true) => return Err(aura_err(Error::MultipleHeaders)),
+			(None, _) => trace!(target: "aura", "Ignoring digest not meant for us"),
+			(s, false) => pre_digest = s,
+		}
+	}
+	pre_digest.ok_or_else(|| aura_err(Error::NoDigestFound))
+}
+
+fn authorities<A, B, C>(
+	client: &C,
+	parent_hash: B::Hash,
+	context_block_number: NumberFor<B>,
+	compatibility_mode: &CompatibilityMode<NumberFor<B>>,
+) -> Result<Vec<A>, ConsensusError>
+where
+	A: Codec + Debug,
+	B: BlockT,
+	C: ProvideRuntimeApi<B>,
+	C::Api: AuraApi<B, A>,
+{
+	let runtime_api = client.runtime_api();
+
+	match compatibility_mode {
+		CompatibilityMode::None => {},
+		// Use `initialize_block` until we hit the block that should disable the mode.
+		CompatibilityMode::UseInitializeBlock { until } =>
+			if *until > context_block_number {
+				runtime_api
+					.initialize_block(
+						&BlockId::Hash(parent_hash),
+						&B::Header::new(
+							context_block_number,
+							Default::default(),
+							Default::default(),
+							parent_hash,
+							Default::default(),
+						),
+					)
+					.map_err(|_| sp_consensus::Error::InvalidAuthoritiesSet)?;
+			},
+	}
+
+	runtime_api
+		.authorities(&BlockId::Hash(parent_hash))
+		.ok()
+		.ok_or(sp_consensus::Error::InvalidAuthoritiesSet)
+}
+

--- a/node/consensus-transition/manual-seal/Cargo.toml
+++ b/node/consensus-transition/manual-seal/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "sc-consensus-manual-seal"
+version = "0.10.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Manual sealing engine for Substrate"
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+thiserror = "1.0"
+futures = "0.3.21"
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+log = "0.4.8"
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+serde = { version = "1.0", features = ["derive"] }
+assert_matches = "1.3.0"
+async-trait = "0.1.50"
+
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-consensus-aura = { path = "../aura", default-features = false }
+sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros"] }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+substrate-test-runtime-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }

--- a/node/consensus-transition/manual-seal/src/consensus.rs
+++ b/node/consensus-transition/manual-seal/src/consensus.rs
@@ -1,0 +1,46 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Extensions for manual seal to produce blocks valid for any runtime.
+use super::Error;
+
+use sc_consensus::BlockImportParams;
+use sp_inherents::InherentData;
+use sp_runtime::{traits::Block as BlockT, Digest};
+
+pub mod aura;
+pub mod babe;
+pub mod timestamp;
+
+/// Consensus data provider, manual seal uses this trait object for authoring blocks valid
+/// for any runtime.
+pub trait ConsensusDataProvider<B: BlockT>: Send + Sync {
+	/// Block import transaction type
+	type Transaction;
+
+	/// Attempt to create a consensus digest.
+	fn create_digest(&self, parent: &B::Header, inherents: &InherentData) -> Result<Digest, Error>;
+
+	/// set up the neccessary import params.
+	fn append_block_import(
+		&self,
+		parent: &B::Header,
+		params: &mut BlockImportParams<B, Self::Transaction>,
+		inherents: &InherentData,
+	) -> Result<(), Error>;
+}

--- a/node/consensus-transition/manual-seal/src/consensus/aura.rs
+++ b/node/consensus-transition/manual-seal/src/consensus/aura.rs
@@ -1,0 +1,98 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Aura consensus data provider, This allows manual seal author blocks that are valid for
+//! runtimes that expect the aura-specific digests.
+
+use crate::{ConsensusDataProvider, Error};
+use sc_client_api::{AuxStore, UsageProvider};
+use sc_consensus::BlockImportParams;
+use sp_api::{ProvideRuntimeApi, TransactionFor};
+use sp_blockchain::{HeaderBackend, HeaderMetadata};
+use sp_consensus_aura::{
+	digests::CompatibleDigestItem,
+	sr25519::{AuthorityId, AuthoritySignature},
+	AuraApi, Slot, SlotDuration,
+};
+use sp_inherents::InherentData;
+use sp_runtime::{traits::Block as BlockT, Digest, DigestItem};
+use sp_timestamp::TimestampInherentData;
+use std::{marker::PhantomData, sync::Arc};
+
+/// Consensus data provider for Aura.
+pub struct AuraConsensusDataProvider<B, C> {
+	// slot duration
+	slot_duration: SlotDuration,
+	// phantom data for required generics
+	_phantom: PhantomData<(B, C)>,
+}
+
+impl<B, C> AuraConsensusDataProvider<B, C>
+where
+	B: BlockT,
+	C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
+	C::Api: AuraApi<B, AuthorityId>,
+{
+	/// Creates a new instance of the [`AuraConsensusDataProvider`], requires that `client`
+	/// implements [`sp_consensus_aura::AuraApi`]
+	pub fn new(client: Arc<C>) -> Self {
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)
+			.expect("slot_duration is always present; qed.");
+
+		Self { slot_duration, _phantom: PhantomData }
+	}
+}
+
+impl<B, C> ConsensusDataProvider<B> for AuraConsensusDataProvider<B, C>
+where
+	B: BlockT,
+	C: AuxStore
+		+ HeaderBackend<B>
+		+ HeaderMetadata<B, Error = sp_blockchain::Error>
+		+ UsageProvider<B>
+		+ ProvideRuntimeApi<B>,
+	C::Api: AuraApi<B, AuthorityId>,
+{
+	type Transaction = TransactionFor<C, B>;
+
+	fn create_digest(
+		&self,
+		_parent: &B::Header,
+		inherents: &InherentData,
+	) -> Result<Digest, Error> {
+		let timestamp =
+			inherents.timestamp_inherent_data()?.expect("Timestamp is always present; qed");
+
+		// we always calculate the new slot number based on the current time-stamp and the slot
+		// duration.
+		let digest_item = <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(
+			Slot::from_timestamp(timestamp, self.slot_duration),
+		);
+
+		Ok(Digest { logs: vec![digest_item] })
+	}
+
+	fn append_block_import(
+		&self,
+		_parent: &B::Header,
+		_params: &mut BlockImportParams<B, Self::Transaction>,
+		_inherents: &InherentData,
+	) -> Result<(), Error> {
+		Ok(())
+	}
+}

--- a/node/consensus-transition/manual-seal/src/consensus/babe.rs
+++ b/node/consensus-transition/manual-seal/src/consensus/babe.rs
@@ -1,0 +1,314 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! BABE consensus data provider, This allows manual seal author blocks that are valid for runtimes
+//! that expect babe-specific digests.
+
+use super::ConsensusDataProvider;
+use crate::Error;
+use codec::Encode;
+use sc_client_api::{AuxStore, UsageProvider};
+use sc_consensus_babe::{
+	authorship, find_pre_digest, BabeIntermediate, CompatibleDigestItem, Config, Epoch,
+	INTERMEDIATE_KEY,
+};
+use sc_consensus_epochs::{
+	descendent_query, EpochHeader, SharedEpochChanges, ViableEpochDescriptor,
+};
+use sp_keystore::SyncCryptoStorePtr;
+use std::{borrow::Cow, sync::Arc};
+
+use sc_consensus::{BlockImportParams, ForkChoiceStrategy, Verifier};
+use sp_api::{ProvideRuntimeApi, TransactionFor};
+use sp_blockchain::{HeaderBackend, HeaderMetadata};
+use sp_consensus::CacheKeyId;
+use sp_consensus_babe::{
+	digests::{NextEpochDescriptor, PreDigest, SecondaryPlainPreDigest},
+	inherents::BabeInherentData,
+	AuthorityId, BabeApi, BabeAuthorityWeight, ConsensusLog, BABE_ENGINE_ID,
+};
+use sp_consensus_slots::Slot;
+use sp_inherents::InherentData;
+use sp_runtime::{
+	generic::{BlockId, Digest},
+	traits::{Block as BlockT, Header},
+	DigestItem,
+};
+use sp_timestamp::TimestampInherentData;
+
+/// Provides BABE-compatible predigests and BlockImportParams.
+/// Intended for use with BABE runtimes.
+pub struct BabeConsensusDataProvider<B: BlockT, C> {
+	/// shared reference to keystore
+	keystore: SyncCryptoStorePtr,
+
+	/// Shared reference to the client.
+	client: Arc<C>,
+
+	/// Shared epoch changes
+	epoch_changes: SharedEpochChanges<B, Epoch>,
+
+	/// BABE config, gotten from the runtime.
+	config: Config,
+
+	/// Authorities to be used for this babe chain.
+	authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
+}
+
+/// Verifier to be used for babe chains
+pub struct BabeVerifier<B: BlockT, C> {
+	/// Shared epoch changes
+	epoch_changes: SharedEpochChanges<B, Epoch>,
+
+	/// Shared reference to the client.
+	client: Arc<C>,
+}
+
+impl<B: BlockT, C> BabeVerifier<B, C> {
+	/// create a nrew verifier
+	pub fn new(epoch_changes: SharedEpochChanges<B, Epoch>, client: Arc<C>) -> BabeVerifier<B, C> {
+		BabeVerifier { epoch_changes, client }
+	}
+}
+
+/// The verifier for the manual seal engine; instantly finalizes.
+#[async_trait::async_trait]
+impl<B, C> Verifier<B> for BabeVerifier<B, C>
+where
+	B: BlockT,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error = sp_blockchain::Error>,
+{
+	async fn verify(
+		&mut self,
+		mut import_params: BlockImportParams<B, ()>,
+	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		import_params.finalized = false;
+		import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
+		let pre_digest = find_pre_digest::<B>(&import_params.header)?;
+
+		let parent_hash = import_params.header.parent_hash();
+		let parent = self
+			.client
+			.header(BlockId::Hash(*parent_hash))
+			.ok()
+			.flatten()
+			.ok_or_else(|| format!("header for block {} not found", parent_hash))?;
+		let epoch_changes = self.epoch_changes.shared_data();
+		let epoch_descriptor = epoch_changes
+			.epoch_descriptor_for_child_of(
+				descendent_query(&*self.client),
+				&parent.hash(),
+				parent.number().clone(),
+				pre_digest.slot(),
+			)
+			.map_err(|e| format!("failed to fetch epoch_descriptor: {}", e))?
+			.ok_or_else(|| format!("{}", sp_consensus::Error::InvalidAuthoritiesSet))?;
+		// drop the lock
+		drop(epoch_changes);
+
+		import_params.intermediates.insert(
+			Cow::from(INTERMEDIATE_KEY),
+			Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
+		);
+
+		Ok((import_params, None))
+	}
+}
+
+impl<B, C> BabeConsensusDataProvider<B, C>
+where
+	B: BlockT,
+	C: AuxStore
+		+ HeaderBackend<B>
+		+ ProvideRuntimeApi<B>
+		+ HeaderMetadata<B, Error = sp_blockchain::Error>
+		+ UsageProvider<B>,
+	C::Api: BabeApi<B>,
+{
+	pub fn new(
+		client: Arc<C>,
+		keystore: SyncCryptoStorePtr,
+		epoch_changes: SharedEpochChanges<B, Epoch>,
+		authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
+	) -> Result<Self, Error> {
+		if authorities.is_empty() {
+			return Err(Error::StringError("Cannot supply empty authority set!".into()))
+		}
+
+		let config = Config::get(&*client)?;
+
+		Ok(Self { config, client, keystore, epoch_changes, authorities })
+	}
+
+	fn epoch(&self, parent: &B::Header, slot: Slot) -> Result<Epoch, Error> {
+		let epoch_changes = self.epoch_changes.shared_data();
+		let epoch_descriptor = epoch_changes
+			.epoch_descriptor_for_child_of(
+				descendent_query(&*self.client),
+				&parent.hash(),
+				parent.number().clone(),
+				slot,
+			)
+			.map_err(|e| Error::StringError(format!("failed to fetch epoch_descriptor: {}", e)))?
+			.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet)?;
+
+		let epoch = epoch_changes
+			.viable_epoch(&epoch_descriptor, |slot| {
+				Epoch::genesis(self.config.genesis_config(), slot)
+			})
+			.ok_or_else(|| {
+				log::info!(target: "babe", "create_digest: no viable_epoch :(");
+				sp_consensus::Error::InvalidAuthoritiesSet
+			})?;
+
+		Ok(epoch.as_ref().clone())
+	}
+}
+
+impl<B, C> ConsensusDataProvider<B> for BabeConsensusDataProvider<B, C>
+where
+	B: BlockT,
+	C: AuxStore
+		+ HeaderBackend<B>
+		+ HeaderMetadata<B, Error = sp_blockchain::Error>
+		+ UsageProvider<B>
+		+ ProvideRuntimeApi<B>,
+	C::Api: BabeApi<B>,
+{
+	type Transaction = TransactionFor<C, B>;
+
+	fn create_digest(&self, parent: &B::Header, inherents: &InherentData) -> Result<Digest, Error> {
+		let slot = inherents
+			.babe_inherent_data()?
+			.ok_or_else(|| Error::StringError("No babe inherent data".into()))?;
+		let epoch = self.epoch(parent, slot)?;
+
+		// this is a dev node environment, we should always be able to claim a slot.
+		let logs = if let Some((predigest, _)) =
+			authorship::claim_slot(slot, &epoch, &self.keystore)
+		{
+			vec![<DigestItem as CompatibleDigestItem>::babe_pre_digest(predigest)]
+		} else {
+			// well we couldn't claim a slot because this is an existing chain and we're not in the
+			// authorities. we need to tell BabeBlockImport that the epoch has changed, and we put
+			// ourselves in the authorities.
+			let predigest =
+				PreDigest::SecondaryPlain(SecondaryPlainPreDigest { slot, authority_index: 0_u32 });
+
+			let mut epoch_changes = self.epoch_changes.shared_data();
+			let epoch_descriptor = epoch_changes
+				.epoch_descriptor_for_child_of(
+					descendent_query(&*self.client),
+					&parent.hash(),
+					parent.number().clone(),
+					slot,
+				)
+				.map_err(|e| {
+					Error::StringError(format!("failed to fetch epoch_descriptor: {}", e))
+				})?
+				.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet)?;
+
+			match epoch_descriptor {
+				ViableEpochDescriptor::Signaled(identifier, _epoch_header) => {
+					let epoch_mut = epoch_changes
+						.epoch_mut(&identifier)
+						.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet)?;
+
+					// mutate the current epoch
+					epoch_mut.authorities = self.authorities.clone();
+
+					let next_epoch = ConsensusLog::NextEpochData(NextEpochDescriptor {
+						authorities: self.authorities.clone(),
+						// copy the old randomness
+						randomness: epoch_mut.randomness.clone(),
+					});
+
+					vec![
+						DigestItem::PreRuntime(BABE_ENGINE_ID, predigest.encode()),
+						DigestItem::Consensus(BABE_ENGINE_ID, next_epoch.encode()),
+					]
+				},
+				ViableEpochDescriptor::UnimportedGenesis(_) => {
+					// since this is the genesis, secondary predigest works for now.
+					vec![DigestItem::PreRuntime(BABE_ENGINE_ID, predigest.encode())]
+				},
+			}
+		};
+
+		Ok(Digest { logs })
+	}
+
+	fn append_block_import(
+		&self,
+		parent: &B::Header,
+		params: &mut BlockImportParams<B, Self::Transaction>,
+		inherents: &InherentData,
+	) -> Result<(), Error> {
+		let slot = inherents
+			.babe_inherent_data()?
+			.ok_or_else(|| Error::StringError("No babe inherent data".into()))?;
+		let epoch_changes = self.epoch_changes.shared_data();
+		let mut epoch_descriptor = epoch_changes
+			.epoch_descriptor_for_child_of(
+				descendent_query(&*self.client),
+				&parent.hash(),
+				parent.number().clone(),
+				slot,
+			)
+			.map_err(|e| Error::StringError(format!("failed to fetch epoch_descriptor: {}", e)))?
+			.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet)?;
+		// drop the lock
+		drop(epoch_changes);
+		// a quick check to see if we're in the authorities
+		let epoch = self.epoch(parent, slot)?;
+		let (authority, _) = self.authorities.first().expect("authorities is non-emptyp; qed");
+		let has_authority = epoch.authorities.iter().any(|(id, _)| *id == *authority);
+
+		if !has_authority {
+			log::info!(target: "manual-seal", "authority not found");
+			let timestamp = inherents
+				.timestamp_inherent_data()?
+				.ok_or_else(|| Error::StringError("No timestamp inherent data".into()))?;
+
+			let slot = Slot::from_timestamp(timestamp, self.config.slot_duration());
+
+			// manually hard code epoch descriptor
+			epoch_descriptor = match epoch_descriptor {
+				ViableEpochDescriptor::Signaled(identifier, _header) =>
+					ViableEpochDescriptor::Signaled(
+						identifier,
+						EpochHeader {
+							start_slot: slot,
+							end_slot: (*slot * self.config.genesis_config().epoch_length).into(),
+						},
+					),
+				_ => unreachable!(
+					"we're not in the authorities, so this isn't the genesis epoch; qed"
+				),
+			};
+		}
+
+		params.intermediates.insert(
+			Cow::from(INTERMEDIATE_KEY),
+			Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
+		);
+
+		Ok(())
+	}
+}

--- a/node/consensus-transition/manual-seal/src/consensus/timestamp.rs
+++ b/node/consensus-transition/manual-seal/src/consensus/timestamp.rs
@@ -1,0 +1,164 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Mocked timestamp inherent, allows for manual seal to create blocks for runtimes
+//! that expect this inherent.
+
+use crate::Error;
+use sc_client_api::{AuxStore, UsageProvider};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_consensus_aura::{
+	sr25519::{AuthorityId, AuthoritySignature},
+	AuraApi,
+};
+use sp_consensus_babe::BabeApi;
+use sp_consensus_slots::{Slot, SlotDuration};
+use sp_inherents::{InherentData, InherentDataProvider, InherentIdentifier};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Zero},
+};
+use sp_timestamp::{InherentType, INHERENT_IDENTIFIER};
+use std::{
+	sync::{atomic, Arc},
+	time::SystemTime,
+};
+
+/// Provide duration since unix epoch in millisecond for timestamp inherent.
+/// Mocks the timestamp inherent to always produce a valid timestamp for the next slot.
+///
+/// This works by either fetching the `slot_number` from the most recent header and dividing
+/// that value by `slot_duration` in order to fork chains that expect this inherent.
+///
+/// It produces timestamp inherents that are increaed by `slot_duraation` whenever
+/// `provide_inherent_data` is called.
+pub struct SlotTimestampProvider {
+	// holds the unix millisecnd timestamp for the most recent block
+	unix_millis: atomic::AtomicU64,
+	// configured slot_duration in the runtime
+	slot_duration: SlotDuration,
+}
+
+impl SlotTimestampProvider {
+	/// Create a new mocked time stamp provider, for babe.
+	pub fn new_babe<B, C>(client: Arc<C>) -> Result<Self, Error>
+	where
+		B: BlockT,
+		C: AuxStore + HeaderBackend<B> + ProvideRuntimeApi<B> + UsageProvider<B>,
+		C::Api: BabeApi<B>,
+	{
+		let slot_duration = sc_consensus_babe::Config::get(&*client)?.slot_duration();
+
+		let time = Self::with_header(&client, slot_duration, |header| {
+			let slot_number = *sc_consensus_babe::find_pre_digest::<B>(&header)
+				.map_err(|err| format!("{}", err))?
+				.slot();
+			Ok(slot_number)
+		})?;
+
+		Ok(Self { unix_millis: atomic::AtomicU64::new(time), slot_duration })
+	}
+
+	/// Create a new mocked time stamp provider, for aura
+	pub fn new_aura<B, C>(client: Arc<C>) -> Result<Self, Error>
+	where
+		B: BlockT,
+		C: AuxStore + HeaderBackend<B> + ProvideRuntimeApi<B> + UsageProvider<B>,
+		C::Api: AuraApi<B, AuthorityId>,
+	{
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+
+		let time = Self::with_header(&client, slot_duration, |header| {
+			let slot_number = *sc_consensus_aura::find_pre_digest::<B, AuthoritySignature>(&header)
+				.map_err(|err| format!("{}", err))?;
+			Ok(slot_number)
+		})?;
+
+		Ok(Self { unix_millis: atomic::AtomicU64::new(time), slot_duration })
+	}
+
+	fn with_header<F, C, B>(
+		client: &Arc<C>,
+		slot_duration: SlotDuration,
+		func: F,
+	) -> Result<u64, Error>
+	where
+		B: BlockT,
+		C: AuxStore + HeaderBackend<B> + UsageProvider<B>,
+		F: Fn(B::Header) -> Result<u64, Error>,
+	{
+		let info = client.info();
+
+		// looks like this isn't the first block, rehydrate the fake time.
+		// otherwise we'd be producing blocks for older slots.
+		let time = if info.best_number != Zero::zero() {
+			let header = client
+				.header(BlockId::Hash(info.best_hash))?
+				.ok_or_else(|| "best header not found in the db!".to_string())?;
+			let slot = func(header)?;
+			// add the slot duration so there's no collision of slots
+			(slot * slot_duration.as_millis() as u64) + slot_duration.as_millis() as u64
+		} else {
+			// this is the first block, use the correct time.
+			let now = SystemTime::now();
+			now.duration_since(SystemTime::UNIX_EPOCH)
+				.map_err(|err| Error::StringError(format!("{}", err)))?
+				.as_millis() as u64
+		};
+
+		Ok(time)
+	}
+
+	/// Get the current slot number
+	pub fn slot(&self) -> Slot {
+		Slot::from_timestamp(
+			self.unix_millis.load(atomic::Ordering::SeqCst).into(),
+			self.slot_duration,
+		)
+	}
+
+	/// Gets the current time stamp.
+	pub fn timestamp(&self) -> sp_timestamp::Timestamp {
+		sp_timestamp::Timestamp::new(self.unix_millis.load(atomic::Ordering::SeqCst))
+	}
+}
+
+#[async_trait::async_trait]
+impl InherentDataProvider for SlotTimestampProvider {
+	fn provide_inherent_data(
+		&self,
+		inherent_data: &mut InherentData,
+	) -> Result<(), sp_inherents::Error> {
+		// we update the time here.
+		let new_time: InherentType = self
+			.unix_millis
+			.fetch_add(self.slot_duration.as_millis() as u64, atomic::Ordering::SeqCst)
+			.into();
+		inherent_data.put_data(INHERENT_IDENTIFIER, &new_time)?;
+		Ok(())
+	}
+
+	async fn try_handle_error(
+		&self,
+		_: &InherentIdentifier,
+		_: &[u8],
+	) -> Option<Result<(), sp_inherents::Error>> {
+		None
+	}
+}

--- a/node/consensus-transition/manual-seal/src/error.rs
+++ b/node/consensus-transition/manual-seal/src/error.rs
@@ -1,0 +1,113 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
+//! This is suitable for a testing environment.
+
+use futures::channel::{mpsc::SendError, oneshot};
+use sc_consensus::ImportResult;
+use sp_blockchain::Error as BlockchainError;
+use sp_consensus::Error as ConsensusError;
+use sp_inherents::Error as InherentsError;
+
+/// Error code for rpc
+mod codes {
+	pub const SERVER_SHUTTING_DOWN: i64 = 10_000;
+	pub const BLOCK_IMPORT_FAILED: i64 = 11_000;
+	pub const EMPTY_TRANSACTION_POOL: i64 = 12_000;
+	pub const BLOCK_NOT_FOUND: i64 = 13_000;
+	pub const CONSENSUS_ERROR: i64 = 14_000;
+	pub const INHERENTS_ERROR: i64 = 15_000;
+	pub const BLOCKCHAIN_ERROR: i64 = 16_000;
+	pub const UNKNOWN_ERROR: i64 = 20_000;
+}
+
+/// errors encountered by background block authorship task
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// An error occurred while importing the block
+	#[error("Block import failed: {0:?}")]
+	BlockImportError(ImportResult),
+	/// Transaction pool is empty, cannot create a block
+	#[error(
+		"Transaction pool is empty, set create_empty to true, if you want to create empty blocks"
+	)]
+	EmptyTransactionPool,
+	/// encountered during creation of Proposer.
+	#[error("Consensus Error: {0}")]
+	ConsensusError(#[from] ConsensusError),
+	/// Failed to create Inherents data
+	#[error("Inherents Error: {0}")]
+	InherentError(#[from] InherentsError),
+	/// error encountered during finalization
+	#[error("Finalization Error: {0}")]
+	BlockchainError(#[from] BlockchainError),
+	/// Supplied parent_hash doesn't exist in chain
+	#[error("Supplied parent_hash: {0} doesn't exist in chain")]
+	BlockNotFound(String),
+	/// Some string error
+	#[error("{0}")]
+	StringError(String),
+	/// send error
+	#[error("Consensus process is terminating")]
+	Canceled(#[from] oneshot::Canceled),
+	/// send error
+	#[error("Consensus process is terminating")]
+	SendError(#[from] SendError),
+	/// Some other error.
+	#[error("Other error: {0}")]
+	Other(#[from] Box<dyn std::error::Error + Send>),
+}
+
+impl From<ImportResult> for Error {
+	fn from(err: ImportResult) -> Self {
+		Error::BlockImportError(err)
+	}
+}
+
+impl From<String> for Error {
+	fn from(s: String) -> Self {
+		Error::StringError(s)
+	}
+}
+
+impl Error {
+	fn to_code(&self) -> i64 {
+		use Error::*;
+		match self {
+			BlockImportError(_) => codes::BLOCK_IMPORT_FAILED,
+			BlockNotFound(_) => codes::BLOCK_NOT_FOUND,
+			EmptyTransactionPool => codes::EMPTY_TRANSACTION_POOL,
+			ConsensusError(_) => codes::CONSENSUS_ERROR,
+			InherentError(_) => codes::INHERENTS_ERROR,
+			BlockchainError(_) => codes::BLOCKCHAIN_ERROR,
+			SendError(_) | Canceled(_) => codes::SERVER_SHUTTING_DOWN,
+			_ => codes::UNKNOWN_ERROR,
+		}
+	}
+}
+
+impl From<Error> for jsonrpc_core::Error {
+	fn from(error: Error) -> Self {
+		jsonrpc_core::Error {
+			code: jsonrpc_core::ErrorCode::ServerError(error.to_code()),
+			message: format!("{}", error),
+			data: None,
+		}
+	}
+}

--- a/node/consensus-transition/manual-seal/src/finalize_block.rs
+++ b/node/consensus-transition/manual-seal/src/finalize_block.rs
@@ -1,0 +1,59 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Block finalization utilities
+
+use crate::rpc;
+use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
+use sp_runtime::{generic::BlockId, traits::Block as BlockT, Justification};
+use std::{marker::PhantomData, sync::Arc};
+
+/// params for block finalization.
+pub struct FinalizeBlockParams<B: BlockT, F, CB> {
+	/// hash of the block
+	pub hash: <B as BlockT>::Hash,
+	/// sender to report errors/success to the rpc.
+	pub sender: rpc::Sender<()>,
+	/// finalization justification
+	pub justification: Option<Justification>,
+	/// Finalizer trait object.
+	pub finalizer: Arc<F>,
+	/// phantom type to pin the Backend type
+	pub _phantom: PhantomData<CB>,
+}
+
+/// finalizes a block in the backend with the given params.
+pub async fn finalize_block<B, F, CB>(params: FinalizeBlockParams<B, F, CB>)
+where
+	B: BlockT,
+	F: Finalizer<B, CB>,
+	CB: ClientBackend<B>,
+{
+	let FinalizeBlockParams { hash, mut sender, justification, finalizer, .. } = params;
+
+	match finalizer.finalize_block(BlockId::Hash(hash), justification, true) {
+		Err(e) => {
+			log::warn!("Failed to finalize block {}", e);
+			rpc::send_result(&mut sender, Err(e.into()))
+		},
+		Ok(()) => {
+			log::info!("✅ Successfully finalized block: {}", hash);
+			rpc::send_result(&mut sender, Ok(()))
+		},
+	}
+}

--- a/node/consensus-transition/manual-seal/src/lib.rs
+++ b/node/consensus-transition/manual-seal/src/lib.rs
@@ -1,0 +1,601 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
+//! This is suitable for a testing environment.
+
+use futures::prelude::*;
+use prometheus_endpoint::Registry;
+use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
+use sc_consensus::{
+	block_import::{BlockImport, BlockImportParams, ForkChoiceStrategy},
+	import_queue::{BasicQueue, BoxBlockImport, Verifier},
+};
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{CacheKeyId, Environment, Proposer, SelectChain};
+use sp_inherents::CreateInherentDataProviders;
+use sp_runtime::{traits::Block as BlockT, ConsensusEngineId};
+use std::{marker::PhantomData, sync::Arc};
+
+mod error;
+mod finalize_block;
+mod seal_block;
+
+pub mod consensus;
+pub mod rpc;
+
+pub use self::{
+	consensus::ConsensusDataProvider,
+	error::Error,
+	finalize_block::{finalize_block, FinalizeBlockParams},
+	rpc::{CreatedBlock, EngineCommand},
+	seal_block::{seal_block, SealBlockParams, MAX_PROPOSAL_DURATION},
+};
+use sc_transaction_pool_api::TransactionPool;
+use sp_api::{ProvideRuntimeApi, TransactionFor};
+
+/// The `ConsensusEngineId` of Manual Seal.
+pub const MANUAL_SEAL_ENGINE_ID: ConsensusEngineId = [b'm', b'a', b'n', b'l'];
+
+/// The verifier for the manual seal engine; instantly finalizes.
+struct ManualSealVerifier;
+
+#[async_trait::async_trait]
+impl<B: BlockT> Verifier<B> for ManualSealVerifier {
+	async fn verify(
+		&mut self,
+		mut block: BlockImportParams<B, ()>,
+	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		block.finalized = false;
+		block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+		Ok((block, None))
+	}
+}
+
+/// Instantiate the import queue for the manual seal consensus engine.
+pub fn import_queue<Block, Transaction>(
+	block_import: BoxBlockImport<Block, Transaction>,
+	spawner: &impl sp_core::traits::SpawnEssentialNamed,
+	registry: Option<&Registry>,
+) -> BasicQueue<Block, Transaction>
+where
+	Block: BlockT,
+	Transaction: Send + Sync + 'static,
+{
+	BasicQueue::new(ManualSealVerifier, block_import, None, spawner, registry)
+}
+
+/// Params required to start the instant sealing authorship task.
+pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, TP, SC, CS, CIDP> {
+	/// Block import instance for well. importing blocks.
+	pub block_import: BI,
+
+	/// The environment we are producing blocks for.
+	pub env: E,
+
+	/// Client instance
+	pub client: Arc<C>,
+
+	/// Shared reference to the transaction pool.
+	pub pool: Arc<TP>,
+
+	/// Stream<Item = EngineCommands>, Basically the receiving end of a channel for sending
+	/// commands to the authorship task.
+	pub commands_stream: CS,
+
+	/// SelectChain strategy.
+	pub select_chain: SC,
+
+	/// Digest provider for inclusion in blocks.
+	pub consensus_data_provider:
+		Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
+
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+}
+
+/// Params required to start the manual sealing authorship task.
+pub struct InstantSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, TP, SC, CIDP> {
+	/// Block import instance for well. importing blocks.
+	pub block_import: BI,
+
+	/// The environment we are producing blocks for.
+	pub env: E,
+
+	/// Client instance
+	pub client: Arc<C>,
+
+	/// Shared reference to the transaction pool.
+	pub pool: Arc<TP>,
+
+	/// SelectChain strategy.
+	pub select_chain: SC,
+
+	/// Digest provider for inclusion in blocks.
+	pub consensus_data_provider:
+		Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
+
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: CIDP,
+}
+
+/// Creates the background authorship task for the manual seal engine.
+pub async fn run_manual_seal<B, BI, CB, E, C, TP, SC, CS, CIDP>(
+	ManualSealParams {
+		mut block_import,
+		mut env,
+		client,
+		pool,
+		mut commands_stream,
+		select_chain,
+		consensus_data_provider,
+		create_inherent_data_providers,
+	}: ManualSealParams<B, BI, E, C, TP, SC, CS, CIDP>,
+) where
+	B: BlockT + 'static,
+	BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
+		+ Send
+		+ Sync
+		+ 'static,
+	C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
+	CB: ClientBackend<B> + 'static,
+	E: Environment<B> + 'static,
+	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
+	CS: Stream<Item = EngineCommand<<B as BlockT>::Hash>> + Unpin + 'static,
+	SC: SelectChain<B> + 'static,
+	TransactionFor<C, B>: 'static,
+	TP: TransactionPool<Block = B>,
+	CIDP: CreateInherentDataProviders<B, ()>,
+{
+	while let Some(command) = commands_stream.next().await {
+		match command {
+			EngineCommand::SealNewBlock { create_empty, finalize, parent_hash, sender } => {
+				seal_block(SealBlockParams {
+					sender,
+					parent_hash,
+					finalize,
+					create_empty,
+					env: &mut env,
+					select_chain: &select_chain,
+					block_import: &mut block_import,
+					consensus_data_provider: consensus_data_provider.as_deref(),
+					pool: pool.clone(),
+					client: client.clone(),
+					create_inherent_data_providers: &create_inherent_data_providers,
+				})
+				.await;
+			},
+			EngineCommand::FinalizeBlock { hash, sender, justification } => {
+				let justification = justification.map(|j| (MANUAL_SEAL_ENGINE_ID, j));
+				finalize_block(FinalizeBlockParams {
+					hash,
+					sender,
+					justification,
+					finalizer: client.clone(),
+					_phantom: PhantomData,
+				})
+				.await
+			},
+		}
+	}
+}
+
+/// runs the background authorship task for the instant seal engine.
+/// instant-seal creates a new block for every transaction imported into
+/// the transaction pool.
+pub async fn run_instant_seal<B, BI, CB, E, C, TP, SC, CIDP>(
+	InstantSealParams {
+		block_import,
+		env,
+		client,
+		pool,
+		select_chain,
+		consensus_data_provider,
+		create_inherent_data_providers,
+	}: InstantSealParams<B, BI, E, C, TP, SC, CIDP>,
+) where
+	B: BlockT + 'static,
+	BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
+		+ Send
+		+ Sync
+		+ 'static,
+	C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
+	CB: ClientBackend<B> + 'static,
+	E: Environment<B> + 'static,
+	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
+	SC: SelectChain<B> + 'static,
+	TransactionFor<C, B>: 'static,
+	TP: TransactionPool<Block = B>,
+	CIDP: CreateInherentDataProviders<B, ()>,
+{
+	// instant-seal creates blocks as soon as transactions are imported
+	// into the transaction pool.
+	let commands_stream = pool.import_notification_stream().map(|_| EngineCommand::SealNewBlock {
+		create_empty: false,
+		finalize: false,
+		parent_hash: None,
+		sender: None,
+	});
+
+	run_manual_seal(ManualSealParams {
+		block_import,
+		env,
+		client,
+		pool,
+		commands_stream,
+		select_chain,
+		consensus_data_provider,
+		create_inherent_data_providers,
+	})
+	.await
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sc_basic_authorship::ProposerFactory;
+	use sc_client_api::BlockBackend;
+	use sc_consensus::ImportedAux;
+	use sc_transaction_pool::{BasicPool, Options, RevalidationType};
+	use sc_transaction_pool_api::{MaintainedTransactionPool, TransactionPool, TransactionSource};
+	use sp_inherents::InherentData;
+	use sp_runtime::generic::{BlockId, Digest, DigestItem};
+	use substrate_test_runtime_client::{
+		AccountKeyring::*, DefaultTestClientBuilderExt, TestClientBuilder, TestClientBuilderExt,
+	};
+	use substrate_test_runtime_transaction_pool::{uxt, TestApi};
+
+	fn api() -> Arc<TestApi> {
+		Arc::new(TestApi::empty())
+	}
+
+	const SOURCE: TransactionSource = TransactionSource::External;
+
+	struct TestDigestProvider<C> {
+		_client: Arc<C>,
+	}
+	impl<B, C> ConsensusDataProvider<B> for TestDigestProvider<C>
+	where
+		B: BlockT,
+		C: ProvideRuntimeApi<B> + Send + Sync,
+	{
+		type Transaction = TransactionFor<C, B>;
+
+		fn create_digest(
+			&self,
+			_parent: &B::Header,
+			_inherents: &InherentData,
+		) -> Result<Digest, Error> {
+			Ok(Digest { logs: vec![] })
+		}
+
+		fn append_block_import(
+			&self,
+			_parent: &B::Header,
+			params: &mut BlockImportParams<B, Self::Transaction>,
+			_inherents: &InherentData,
+		) -> Result<(), Error> {
+			params.post_digests.push(DigestItem::Other(vec![1]));
+			Ok(())
+		}
+	}
+
+	#[tokio::test]
+	async fn instant_seal() {
+		let builder = TestClientBuilder::new();
+		let (client, select_chain) = builder.build_with_longest_chain();
+		let client = Arc::new(client);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let pool = Arc::new(BasicPool::with_revalidation_type(
+			Options::default(),
+			true.into(),
+			api(),
+			None,
+			RevalidationType::Full,
+			spawner.clone(),
+			0,
+		));
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
+		// this test checks that blocks are created as soon as transactions are imported into the
+		// pool.
+		let (sender, receiver) = futures::channel::oneshot::channel();
+		let mut sender = Arc::new(Some(sender));
+		let commands_stream =
+			pool.pool().validated_pool().import_notification_stream().map(move |_| {
+				// we're only going to submit one tx so this fn will only be called once.
+				let mut_sender = Arc::get_mut(&mut sender).unwrap();
+				let sender = std::mem::take(mut_sender);
+				EngineCommand::SealNewBlock {
+					create_empty: false,
+					finalize: true,
+					parent_hash: None,
+					sender,
+				}
+			});
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+			consensus_data_provider: None,
+		});
+		std::thread::spawn(|| {
+			let rt = tokio::runtime::Runtime::new().unwrap();
+			// spawn the background authorship task
+			rt.block_on(future);
+		});
+		// submit a transaction to pool.
+		let result = pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Alice, 0)).await;
+		// assert that it was successfully imported
+		assert!(result.is_ok());
+		// assert that the background task returns ok
+		let created_block = receiver.await.unwrap().unwrap();
+		assert_eq!(
+			created_block,
+			CreatedBlock {
+				hash: created_block.hash.clone(),
+				aux: ImportedAux {
+					header_only: false,
+					clear_justification_requests: false,
+					needs_justification: false,
+					bad_justification: false,
+					is_new_best: true,
+				}
+			}
+		);
+		// assert that there's a new block in the db.
+		assert!(client.header(&BlockId::Number(1)).unwrap().is_some())
+	}
+
+	#[tokio::test]
+	async fn manual_seal_and_finalization() {
+		let builder = TestClientBuilder::new();
+		let (client, select_chain) = builder.build_with_longest_chain();
+		let client = Arc::new(client);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let pool = Arc::new(BasicPool::with_revalidation_type(
+			Options::default(),
+			true.into(),
+			api(),
+			None,
+			RevalidationType::Full,
+			spawner.clone(),
+			0,
+		));
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
+		// this test checks that blocks are created as soon as an engine command is sent over the
+		// stream.
+		let (mut sink, commands_stream) = futures::channel::mpsc::channel(1024);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			consensus_data_provider: None,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+		});
+		std::thread::spawn(|| {
+			let rt = tokio::runtime::Runtime::new().unwrap();
+			// spawn the background authorship task
+			rt.block_on(future);
+		});
+		// submit a transaction to pool.
+		let result = pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Alice, 0)).await;
+		// assert that it was successfully imported
+		assert!(result.is_ok());
+		let (tx, rx) = futures::channel::oneshot::channel();
+		sink.send(EngineCommand::SealNewBlock {
+			parent_hash: None,
+			sender: Some(tx),
+			create_empty: false,
+			finalize: false,
+		})
+		.await
+		.unwrap();
+		let created_block = rx.await.unwrap().unwrap();
+
+		// assert that the background task returns ok
+		assert_eq!(
+			created_block,
+			CreatedBlock {
+				hash: created_block.hash.clone(),
+				aux: ImportedAux {
+					header_only: false,
+					clear_justification_requests: false,
+					needs_justification: false,
+					bad_justification: false,
+					is_new_best: true,
+				}
+			}
+		);
+		// assert that there's a new block in the db.
+		let header = client.header(&BlockId::Number(1)).unwrap().unwrap();
+		let (tx, rx) = futures::channel::oneshot::channel();
+		sink.send(EngineCommand::FinalizeBlock {
+			sender: Some(tx),
+			hash: header.hash(),
+			justification: None,
+		})
+		.await
+		.unwrap();
+		// check that the background task returns ok:
+		rx.await.unwrap().unwrap();
+	}
+
+	#[tokio::test]
+	async fn manual_seal_fork_blocks() {
+		let builder = TestClientBuilder::new();
+		let (client, select_chain) = builder.build_with_longest_chain();
+		let client = Arc::new(client);
+		let pool_api = api();
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let pool = Arc::new(BasicPool::with_revalidation_type(
+			Options::default(),
+			true.into(),
+			pool_api.clone(),
+			None,
+			RevalidationType::Full,
+			spawner.clone(),
+			0,
+		));
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
+		// this test checks that blocks are created as soon as an engine command is sent over the
+		// stream.
+		let (mut sink, commands_stream) = futures::channel::mpsc::channel(1024);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			consensus_data_provider: None,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+		});
+		std::thread::spawn(|| {
+			let rt = tokio::runtime::Runtime::new().unwrap();
+			// spawn the background authorship task
+			rt.block_on(future);
+		});
+		// submit a transaction to pool.
+		let result = pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Alice, 0)).await;
+		// assert that it was successfully imported
+		assert!(result.is_ok());
+
+		let (tx, rx) = futures::channel::oneshot::channel();
+		sink.send(EngineCommand::SealNewBlock {
+			parent_hash: None,
+			sender: Some(tx),
+			create_empty: false,
+			finalize: false,
+		})
+		.await
+		.unwrap();
+		let created_block = rx.await.unwrap().unwrap();
+		pool_api.increment_nonce(Alice.into());
+
+		// assert that the background task returns ok
+		assert_eq!(
+			created_block,
+			CreatedBlock {
+				hash: created_block.hash.clone(),
+				aux: ImportedAux {
+					header_only: false,
+					clear_justification_requests: false,
+					needs_justification: false,
+					bad_justification: false,
+					is_new_best: true
+				}
+			}
+		);
+		let block = client.block(&BlockId::Number(1)).unwrap().unwrap().block;
+		pool_api.add_block(block, true);
+		assert!(pool.submit_one(&BlockId::Number(1), SOURCE, uxt(Alice, 1)).await.is_ok());
+
+		let header = client.header(&BlockId::Number(1)).expect("db error").expect("imported above");
+		pool.maintain(sc_transaction_pool_api::ChainEvent::NewBestBlock {
+			hash: header.hash(),
+			tree_route: None,
+		})
+		.await;
+
+		let (tx1, rx1) = futures::channel::oneshot::channel();
+		assert!(sink
+			.send(EngineCommand::SealNewBlock {
+				parent_hash: Some(created_block.hash),
+				sender: Some(tx1),
+				create_empty: false,
+				finalize: false,
+			})
+			.await
+			.is_ok());
+		assert_matches::assert_matches!(rx1.await.expect("should be no error receiving"), Ok(_));
+		let block = client.block(&BlockId::Number(2)).unwrap().unwrap().block;
+		pool_api.add_block(block, true);
+		pool_api.increment_nonce(Alice.into());
+
+		assert!(pool.submit_one(&BlockId::Number(1), SOURCE, uxt(Bob, 0)).await.is_ok());
+		let (tx2, rx2) = futures::channel::oneshot::channel();
+		assert!(sink
+			.send(EngineCommand::SealNewBlock {
+				parent_hash: Some(created_block.hash),
+				sender: Some(tx2),
+				create_empty: false,
+				finalize: false,
+			})
+			.await
+			.is_ok());
+		let imported = rx2.await.unwrap().unwrap();
+		// assert that fork block is in the db
+		assert!(client.header(&BlockId::Hash(imported.hash)).unwrap().is_some())
+	}
+
+	#[tokio::test]
+	async fn manual_seal_post_hash() {
+		let builder = TestClientBuilder::new();
+		let (client, select_chain) = builder.build_with_longest_chain();
+		let client = Arc::new(client);
+		let spawner = sp_core::testing::TaskExecutor::new();
+		let pool = Arc::new(BasicPool::with_revalidation_type(
+			Options::default(),
+			true.into(),
+			api(),
+			None,
+			RevalidationType::Full,
+			spawner.clone(),
+			0,
+		));
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
+
+		let (mut sink, commands_stream) = futures::channel::mpsc::channel(1024);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			// use a provider that pushes some post digest data
+			consensus_data_provider: Some(Box::new(TestDigestProvider { _client: client.clone() })),
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+		});
+		std::thread::spawn(|| {
+			let rt = tokio::runtime::Runtime::new().unwrap();
+			rt.block_on(future);
+		});
+		let (tx, rx) = futures::channel::oneshot::channel();
+		sink.send(EngineCommand::SealNewBlock {
+			parent_hash: None,
+			sender: Some(tx),
+			create_empty: true,
+			finalize: false,
+		})
+		.await
+		.unwrap();
+		let created_block = rx.await.unwrap().unwrap();
+
+		// assert that the background task returned the actual header hash
+		let header = client.header(&BlockId::Number(1)).unwrap().unwrap();
+		assert_eq!(header.hash(), created_block.hash);
+	}
+}

--- a/node/consensus-transition/manual-seal/src/rpc.rs
+++ b/node/consensus-transition/manual-seal/src/rpc.rs
@@ -1,0 +1,170 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! RPC interface for the `ManualSeal` Engine.
+
+pub use self::gen_client::Client as ManualSealClient;
+use futures::{
+	channel::{mpsc, oneshot},
+	FutureExt, SinkExt, TryFutureExt,
+};
+use jsonrpc_core::Error;
+use jsonrpc_derive::rpc;
+use sc_consensus::ImportedAux;
+use serde::{Deserialize, Serialize};
+use sp_runtime::EncodedJustification;
+
+/// Future's type for jsonrpc
+type FutureResult<T> = jsonrpc_core::BoxFuture<Result<T, Error>>;
+/// sender passed to the authorship task to report errors or successes.
+pub type Sender<T> = Option<oneshot::Sender<std::result::Result<T, crate::Error>>>;
+
+/// Message sent to the background authorship task, usually by RPC.
+pub enum EngineCommand<Hash> {
+	/// Tells the engine to propose a new block
+	///
+	/// if create_empty == true, it will create empty blocks if there are no transactions
+	/// in the transaction pool.
+	///
+	/// if finalize == true, the block will be instantly finalized.
+	SealNewBlock {
+		/// if true, empty blocks(without extrinsics) will be created.
+		/// otherwise, will return Error::EmptyTransactionPool.
+		create_empty: bool,
+		/// instantly finalize this block?
+		finalize: bool,
+		/// specify the parent hash of the about-to-created block
+		parent_hash: Option<Hash>,
+		/// sender to report errors/success to the rpc.
+		sender: Sender<CreatedBlock<Hash>>,
+	},
+	/// Tells the engine to finalize the block with the supplied hash
+	FinalizeBlock {
+		/// hash of the block
+		hash: Hash,
+		/// sender to report errors/success to the rpc.
+		sender: Sender<()>,
+		/// finalization justification
+		justification: Option<EncodedJustification>,
+	},
+}
+
+/// RPC trait that provides methods for interacting with the manual-seal authorship task over rpc.
+#[rpc]
+pub trait ManualSealApi<Hash> {
+	/// Instructs the manual-seal authorship task to create a new block
+	#[rpc(name = "engine_createBlock")]
+	fn create_block(
+		&self,
+		create_empty: bool,
+		finalize: bool,
+		parent_hash: Option<Hash>,
+	) -> FutureResult<CreatedBlock<Hash>>;
+
+	/// Instructs the manual-seal authorship task to finalize a block
+	#[rpc(name = "engine_finalizeBlock")]
+	fn finalize_block(
+		&self,
+		hash: Hash,
+		justification: Option<EncodedJustification>,
+	) -> FutureResult<bool>;
+}
+
+/// A struct that implements the [`ManualSealApi`].
+pub struct ManualSeal<Hash> {
+	import_block_channel: mpsc::Sender<EngineCommand<Hash>>,
+}
+
+/// return type of `engine_createBlock`
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CreatedBlock<Hash> {
+	/// hash of the created block.
+	pub hash: Hash,
+	/// some extra details about the import operation
+	pub aux: ImportedAux,
+}
+
+impl<Hash> ManualSeal<Hash> {
+	/// Create new `ManualSeal` with the given reference to the client.
+	pub fn new(import_block_channel: mpsc::Sender<EngineCommand<Hash>>) -> Self {
+		Self { import_block_channel }
+	}
+}
+
+impl<Hash: Send + 'static> ManualSealApi<Hash> for ManualSeal<Hash> {
+	fn create_block(
+		&self,
+		create_empty: bool,
+		finalize: bool,
+		parent_hash: Option<Hash>,
+	) -> FutureResult<CreatedBlock<Hash>> {
+		let mut sink = self.import_block_channel.clone();
+		async move {
+			let (sender, receiver) = oneshot::channel();
+			let command = EngineCommand::SealNewBlock {
+				create_empty,
+				finalize,
+				parent_hash,
+				sender: Some(sender),
+			};
+			sink.send(command).await?;
+			receiver.await?
+		}
+		.map_err(Error::from)
+		.boxed()
+	}
+
+	fn finalize_block(
+		&self,
+		hash: Hash,
+		justification: Option<EncodedJustification>,
+	) -> FutureResult<bool> {
+		let mut sink = self.import_block_channel.clone();
+		async move {
+			let (sender, receiver) = oneshot::channel();
+			sink.send(EngineCommand::FinalizeBlock { hash, sender: Some(sender), justification })
+				.await?;
+
+			receiver.await?.map(|_| true)
+		}
+		.map_err(Error::from)
+		.boxed()
+	}
+}
+
+/// report any errors or successes encountered by the authorship task back
+/// to the rpc
+pub fn send_result<T: std::fmt::Debug>(
+	sender: &mut Sender<T>,
+	result: std::result::Result<T, crate::Error>,
+) {
+	if let Some(sender) = sender.take() {
+		if let Err(err) = sender.send(result) {
+			match err {
+				Ok(value) => log::warn!("Server is shutting down: {:?}", value),
+				Err(error) => log::warn!("Server is shutting down with error: {}", error),
+			}
+		}
+	} else {
+		// instant seal doesn't report errors over rpc, simply log them.
+		match result {
+			Ok(r) => log::info!("Instant Seal success: {:?}", r),
+			Err(e) => log::error!("Instant Seal encountered an error: {}", e),
+		}
+	}
+}

--- a/node/consensus-transition/manual-seal/src/seal_block.rs
+++ b/node/consensus-transition/manual-seal/src/seal_block.rs
@@ -1,0 +1,166 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Block sealing utilities
+
+use crate::{rpc, ConsensusDataProvider, CreatedBlock, Error};
+use futures::prelude::*;
+use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult, StateAction};
+use sc_transaction_pool_api::TransactionPool;
+use sp_api::{ProvideRuntimeApi, TransactionFor};
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{self, BlockOrigin, Environment, Proposer, SelectChain};
+use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Header as HeaderT},
+};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+/// max duration for creating a proposal in secs
+pub const MAX_PROPOSAL_DURATION: u64 = 10;
+
+/// params for sealing a new block
+pub struct SealBlockParams<'a, B: BlockT, BI, SC, C: ProvideRuntimeApi<B>, E, TP, CIDP> {
+	/// if true, empty blocks(without extrinsics) will be created.
+	/// otherwise, will return Error::EmptyTransactionPool.
+	pub create_empty: bool,
+	/// instantly finalize this block?
+	pub finalize: bool,
+	/// specify the parent hash of the about-to-created block
+	pub parent_hash: Option<<B as BlockT>::Hash>,
+	/// sender to report errors/success to the rpc.
+	pub sender: rpc::Sender<CreatedBlock<<B as BlockT>::Hash>>,
+	/// transaction pool
+	pub pool: Arc<TP>,
+	/// header backend
+	pub client: Arc<C>,
+	/// Environment trait object for creating a proposer
+	pub env: &'a mut E,
+	/// SelectChain object
+	pub select_chain: &'a SC,
+	/// Digest provider for inclusion in blocks.
+	pub consensus_data_provider:
+		Option<&'a dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>,
+	/// block import object
+	pub block_import: &'a mut BI,
+	/// Something that can create the inherent data providers.
+	pub create_inherent_data_providers: &'a CIDP,
+}
+
+/// seals a new block with the given params
+pub async fn seal_block<B, BI, SC, C, E, TP, CIDP>(
+	SealBlockParams {
+		create_empty,
+		finalize,
+		pool,
+		parent_hash,
+		client,
+		select_chain,
+		block_import,
+		env,
+		create_inherent_data_providers,
+		consensus_data_provider: digest_provider,
+		mut sender,
+	}: SealBlockParams<'_, B, BI, SC, C, E, TP, CIDP>,
+) where
+	B: BlockT,
+	BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
+		+ Send
+		+ Sync
+		+ 'static,
+	C: HeaderBackend<B> + ProvideRuntimeApi<B>,
+	E: Environment<B>,
+	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
+	TP: TransactionPool<Block = B>,
+	SC: SelectChain<B>,
+	TransactionFor<C, B>: 'static,
+	CIDP: CreateInherentDataProviders<B, ()>,
+{
+	let future = async {
+		if pool.status().ready == 0 && !create_empty {
+			return Err(Error::EmptyTransactionPool)
+		}
+
+		// get the header to build this new block on.
+		// use the parent_hash supplied via `EngineCommand`
+		// or fetch the best_block.
+		let parent = match parent_hash {
+			Some(hash) => client
+				.header(BlockId::Hash(hash))?
+				.ok_or_else(|| Error::BlockNotFound(format!("{}", hash)))?,
+			None => select_chain.best_chain().await?,
+		};
+
+		let inherent_data_providers = create_inherent_data_providers
+			.create_inherent_data_providers(parent.hash(), ())
+			.await
+			.map_err(|e| Error::Other(e))?;
+
+		let inherent_data = inherent_data_providers.create_inherent_data()?;
+
+		let proposer = env.init(&parent).map_err(|err| Error::StringError(err.to_string())).await?;
+		let inherents_len = inherent_data.len();
+
+		let digest = if let Some(digest_provider) = digest_provider {
+			digest_provider.create_digest(&parent, &inherent_data)?
+		} else {
+			Default::default()
+		};
+
+		let proposal = proposer
+			.propose(
+				inherent_data.clone(),
+				digest,
+				Duration::from_secs(MAX_PROPOSAL_DURATION),
+				None,
+			)
+			.map_err(|err| Error::StringError(err.to_string()))
+			.await?;
+
+		if proposal.block.extrinsics().len() == inherents_len && !create_empty {
+			return Err(Error::EmptyTransactionPool)
+		}
+
+		let (header, body) = proposal.block.deconstruct();
+		let mut params = BlockImportParams::new(BlockOrigin::Own, header.clone());
+		params.body = Some(body);
+		params.finalized = finalize;
+		params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+		params.state_action = StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(
+			proposal.storage_changes,
+		));
+
+		if let Some(digest_provider) = digest_provider {
+			digest_provider.append_block_import(&parent, &mut params, &inherent_data)?;
+		}
+
+		// Make sure we return the same post-hash that will be calculated when importing the block
+		// This is important in case the digest_provider added any signature, seal, ect.
+		let mut post_header = header.clone();
+		post_header.digest_mut().logs.extend(params.post_digests.iter().cloned());
+
+		match block_import.import_block(params, HashMap::new()).await? {
+			ImportResult::Imported(aux) =>
+				Ok(CreatedBlock { hash: <B as BlockT>::Header::hash(&post_header), aux }),
+			other => Err(other.into()),
+		}
+	};
+
+	rpc::send_result(&mut sender, future.await)
+}

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -15,8 +15,8 @@ pallet-contracts-rpc = { git = "https://github.com/paritytech/substrate", branch
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
-sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
+sc-consensus-aura = { path = "../consensus-transition/aura", default-features = false }
+sc-consensus-manual-seal = { path = "../consensus-transition/manual-seal", default-features = false }
 sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }
 sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", default-features = false }


### PR DESCRIPTION
New changes since v4.0.0:

- Ported consensus transition logic to the new substrate convention. {[Block #14555555](https://edgeware.subscan.io/block/14555555) will be the switch. It should ideally happen after the runtime upgrade v4.0.1 on the mainnet.} [**Huge thanks to KDPnetstake for finding the critical node client bug on the previous Beresheet v4 testnet.**]
- Amended the testnet block trigger to span two eras with the old consensus before switching to the new one.
